### PR TITLE
Pbi 6 data visualization download

### DIFF
--- a/curator_feature/serializers.py
+++ b/curator_feature/serializers.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
-from curator_feature.models import DownloadLog, DashboardDownloadEvent
+from curator_feature.models import DashboardDownloadEvent, DownloadLog
 
 
 class CaseInsensitiveChoiceField(serializers.ChoiceField):
+    """Choice field that normalizes string inputs to lower-case before validation."""
+
     def to_internal_value(self, data):
         if isinstance(data, str):
             data = data.lower()
@@ -34,8 +36,70 @@ class DownloadLogResponseSerializer(serializers.ModelSerializer):
         fields = ("id", "username", "chartType", "timestamp", "created_at")
 
 
+class ChartLocationSerializer(serializers.Serializer):
+    provinces = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False, trim_whitespace=True),
+        required=False,
+        allow_empty=True,
+    )
+    cities = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False, trim_whitespace=True),
+        required=False,
+        allow_empty=True,
+    )
+
+
+class ChartDataFiltersSerializer(serializers.Serializer):
+    diseases = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False, trim_whitespace=True),
+        required=False,
+        allow_empty=True,
+    )
+    portals = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False, trim_whitespace=True),
+        required=False,
+        allow_empty=True,
+    )
+    level_of_alertness = serializers.IntegerField(required=False, min_value=1)
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
+    locations = ChartLocationSerializer(required=False)
+
+    def validate_diseases(self, value):
+        return self._unique(value)
+
+    def validate_portals(self, value):
+        return self._unique(value)
+
+    def validate(self, attrs):
+        start = attrs.get("start_date")
+        end = attrs.get("end_date")
+        if start and end and end < start:
+            raise serializers.ValidationError({"end_date": "End date cannot be earlier than start date."})
+        return attrs
+
+    def _unique(self, values):
+        seen = []
+        for item in values:
+            if item not in seen:
+                seen.append(item)
+        return seen
+
+
 class DashboardDownloadEventSerializer(serializers.Serializer):
     metric = CaseInsensitiveChoiceField(choices=DashboardDownloadEvent.Metric.choices)
     file_format = CaseInsensitiveChoiceField(choices=DashboardDownloadEvent.FileFormat.choices)
     filters = serializers.JSONField(required=False)
-    source = serializers.CharField(required=False, allow_blank=True)
+    source = serializers.CharField(max_length=255, required=False, allow_blank=False, trim_whitespace=True)
+
+    def validate_filters(self, value):
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Filters must be an object.")
+        return value
+
+    def validate_source(self, value):
+        if not value:
+            raise serializers.ValidationError("Source may not be blank.")
+        return value

--- a/curator_feature/services.py
+++ b/curator_feature/services.py
@@ -1,9 +1,13 @@
 import logging
-from typing import Any
+from typing import Any, Dict, Optional
 
 from django.db import DatabaseError, transaction
+from django.utils import timezone
 
 from curator_feature.models import DownloadLog
+from pt_backend.repositories import CaseRepository
+from pt_backend.services import CacheService, CaseService, CasesFilterService
+from pt_backend.statistics.coordinator import StatisticsCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +26,239 @@ class DownloadLogService:
         except DatabaseError as exc:
             logger.exception("Failed to persist download log for user=%s chart=%s", username, chart_type)
             raise
+
+
+class ChartDataService:
+    """Provide normalized chart payloads for the curator dashboard."""
+
+    SEVERITY_ORDER = ("hospitalisasi", "insiden", "mortalitas")
+    AGE_BUCKETS = ("under_12", "12_25", "26_45", "above_45")
+
+    def __init__(self, statistics_coordinator: Optional[StatisticsCoordinator] = None):
+        if statistics_coordinator is None:
+            cache_service = CacheService()
+            case_service = CaseService(repository=CaseRepository(), cache_service=cache_service)
+            filter_service = CasesFilterService(case_service)
+            statistics_coordinator = StatisticsCoordinator(case_filter_service=filter_service)
+
+        self.statistics_coordinator = statistics_coordinator
+
+    def get_chart_data(self, *, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        filters = filters or {}
+
+        try:
+            statistics = self.statistics_coordinator.generate_comprehensive_report(**filters)
+        except Exception:
+            logger.exception("Failed to generate curator chart statistics")
+            raise
+
+        charts = self._build_charts(statistics or {})
+        meta = {
+            "filtersApplied": bool(filters),
+            "generatedAt": timezone.now().isoformat(),
+            "source": "curator-dashboard",
+        }
+
+        return {"charts": charts, "meta": meta}
+
+    def _build_charts(self, statistics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "severityDistribution": self._format_severity(statistics.get("severity_statistics")),
+            "ageDistribution": self._format_age(statistics.get("age_statistics")),
+            "genderDistribution": self._format_gender(statistics.get("gender_statistics")),
+            "severityTrendByDate": self._format_trend(statistics.get("severity_dates_count_statistics")),
+            "prevalence": self._format_prevalence(statistics.get("prevalence_statistics")),
+            "newsCoverage": self._format_news_sections(
+                national=statistics.get("national_news_statistics"),
+                local=statistics.get("local_portal_statistics"),
+                healthcare=statistics.get("healthcare_news_statistics"),
+            ),
+        }
+
+    def _format_severity(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        chart = {
+            "chartType": "bar",
+            "data": [],
+            "meta": {"totalCases": 0, "order": list(self.SEVERITY_ORDER)},
+        }
+        if not isinstance(payload, dict):
+            chart["meta"]["error"] = "DATA_UNAVAILABLE"
+            return chart
+
+        if payload.get("error"):
+            chart["meta"]["error"] = payload["error"]
+            return chart
+
+        counts = payload.get("severity_counts") or {}
+        ordered = []
+        for key in self.SEVERITY_ORDER:
+            if key in counts:
+                ordered.append({"severity": key, "count": self._safe_int(counts.get(key, 0))})
+
+        for key, value in counts.items():
+            if key not in self.SEVERITY_ORDER:
+                ordered.append({"severity": key, "count": self._safe_int(value)})
+
+        total_cases = payload.get("total_cases")
+        if total_cases is None:
+            total_cases = sum(item["count"] for item in ordered)
+
+        chart["data"] = ordered
+        chart["meta"]["totalCases"] = self._safe_int(total_cases)
+        return chart
+
+    def _format_age(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        chart = {
+            "chartType": "bar",
+            "data": [],
+            "meta": {"totalResponses": 0, "order": list(self.AGE_BUCKETS)},
+        }
+        if not isinstance(payload, dict):
+            chart["meta"]["error"] = "DATA_UNAVAILABLE"
+            return chart
+
+        if payload.get("error"):
+            chart["meta"]["error"] = payload["error"]
+            return chart
+
+        data = []
+        for bucket in self.AGE_BUCKETS:
+            count = self._safe_int(payload.get(bucket, 0))
+            data.append({"group": bucket, "count": count})
+
+        total = sum(item["count"] for item in data)
+        chart["data"] = data
+        chart["meta"]["totalResponses"] = total
+        return chart
+
+    def _format_gender(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        chart = {
+            "chartType": "pie",
+            "data": [],
+            "meta": {"totalCases": 0, "order": ["male", "female"]},
+        }
+        if not isinstance(payload, dict):
+            chart["meta"]["error"] = "DATA_UNAVAILABLE"
+            return chart
+
+        if payload.get("error"):
+            chart["meta"]["error"] = payload["error"]
+            return chart
+
+        male = self._safe_int(payload.get("male", 0))
+        female = self._safe_int(payload.get("female", 0))
+
+        chart["data"] = [
+            {"gender": "male", "count": male},
+            {"gender": "female", "count": female},
+        ]
+        chart["meta"]["totalCases"] = male + female
+        return chart
+
+    def _format_trend(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        chart = {"chartType": "line", "series": [], "meta": {"seriesCount": 0}}
+        if not isinstance(payload, dict):
+            chart["meta"]["error"] = "DATA_UNAVAILABLE"
+            return chart
+
+        if payload.get("error"):
+            chart["meta"]["error"] = payload["error"]
+            return chart
+
+        series = []
+        for severity, points in payload.items():
+            if not isinstance(points, list):
+                continue
+            normalized_points = []
+            for point in points:
+                date = point.get("date")
+                if not date:
+                    continue
+                normalized_points.append(
+                    {"date": date, "count": self._safe_int(point.get("count", 0))}
+                )
+            if normalized_points:
+                series.append({"severity": severity, "points": normalized_points})
+
+        chart["series"] = series
+        chart["meta"]["seriesCount"] = len(series)
+        return chart
+
+    def _format_prevalence(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        chart = {
+            "chartType": "stat",
+            "data": {"year": None, "totalCases": 0, "population": None, "prevalence": None},
+        }
+        if not isinstance(payload, dict):
+            chart["meta"] = {"error": "DATA_UNAVAILABLE"}
+            return chart
+
+        if payload.get("error"):
+            chart["meta"] = {"error": payload["error"]}
+            return chart
+
+        chart["data"] = {
+            "year": payload.get("year"),
+            "totalCases": self._safe_int(payload.get("total_cases", 0)),
+            "population": self._safe_int(payload.get("population", 0), allow_null=True),
+            "prevalence": payload.get("prevalence"),
+        }
+        return chart
+
+    def _format_news_sections(
+        self,
+        *,
+        national: Optional[Dict[str, Any]],
+        local: Optional[Dict[str, Any]],
+        healthcare: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        return {
+            "chartType": "bar",
+            "national": self._normalize_news_section(national, "top_national", "all_national"),
+            "local": self._normalize_news_section(local, "top_local", "all_local"),
+            "healthcare": self._normalize_news_section(healthcare, "top_healthcare", "all_healthcare"),
+        }
+
+    def _normalize_news_section(self, payload: Optional[Dict[str, Any]], top_key: str, all_key: str) -> Dict[str, Any]:
+        section = {"top": [], "all": [], "meta": {"uniquePortals": 0}}
+        if not isinstance(payload, dict):
+            section["meta"]["error"] = "DATA_UNAVAILABLE"
+            return section
+
+        if payload.get("error"):
+            section["meta"]["error"] = payload["error"]
+            return section
+
+        top_entries = payload.get(top_key) or []
+        all_entries = payload.get(all_key) or []
+
+        section["top"] = [
+            {
+                "portal": entry.get("portal"),
+                "newsCount": self._safe_int(entry.get("count", entry.get("news_count", 0))),
+            }
+            for entry in top_entries
+            if entry.get("portal")
+        ]
+
+        section["all"] = [
+            {
+                "portal": entry.get("portal"),
+                "newsCount": self._safe_int(entry.get("news_count", entry.get("count", 0))),
+                "diseaseCount": self._safe_int(entry.get("disease_count", 0)),
+            }
+            for entry in all_entries
+            if entry.get("portal")
+        ]
+
+        section["meta"]["uniquePortals"] = len(section["all"])
+        return section
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0, *, allow_null: bool = False) -> Optional[int]:
+        if allow_null and value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default

--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -1,4 +1,8 @@
 import os
+from datetime import datetime
+from decimal import Decimal
+
+from django.core.cache import cache
 from django.utils import timezone
 from django.db import DatabaseError
 from rest_framework.test import APITestCase, APIClient
@@ -8,8 +12,148 @@ from unittest.mock import patch
 from django.test import override_settings
 from django.urls import reverse
 
-from pt_backend.models import User
+from pt_backend.models import Case, Disease, Location, News, User
 from curator_feature.models import DownloadLog, DashboardDownloadEvent
+
+
+class ChartDataAPIViewTests(APITestCase):
+    def setUp(self):
+        self.url = "/api/logs/charts/data"
+        self.user = User.objects.create(
+            name="Curator Uno",
+            password="test-pass",
+            role="CURATOR",
+            email="curator@example.com",
+        )
+        token = RefreshToken.for_user(self.user).access_token
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        cache.clear()
+        self._create_dataset()
+
+    def test_requires_authentication(self):
+        unauthenticated = APIClient()
+        response = unauthenticated.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_returns_chart_payload(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        charts = response.data.get("charts", {})
+        self.assertIn("severityDistribution", charts)
+        self.assertIn("meta", response.data)
+        self.assertTrue(response.data["meta"].get("generatedAt"))
+        severity_counts = {
+            item["severity"]: item["count"]
+            for item in charts["severityDistribution"]["data"]
+        }
+        self.assertGreaterEqual(severity_counts.get("hospitalisasi", 0), 1)
+        self.assertGreaterEqual(severity_counts.get("insiden", 0), 1)
+        self.assertEqual(charts["genderDistribution"]["chartType"], "pie")
+        news_section = charts["newsCoverage"]["national"]
+        self.assertEqual(news_section["top"][0]["portal"], "Portal Nasional")
+        self.assertEqual(news_section["top"][0]["newsCount"], 1)
+        trend_series = charts["severityTrendByDate"]["series"]
+        self.assertTrue(any(series["points"] for series in trend_series))
+
+    def test_filters_set_meta_flag(self):
+        payload = {
+            "diseases": ["Demam Berdarah"],
+            "locations": {"provinces": ["Jawa Barat"]},
+        }
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["meta"]["filtersApplied"])
+
+    def test_invalid_date_range_returns_400(self):
+        payload = {"start_date": "2024-02-01", "end_date": "2024-01-01"}
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", response.data)
+        self.assertIn("end_date", response.data["errors"])
+
+    def _create_dataset(self):
+        disease_flu = Disease.objects.create(name="Flu", level_of_alertness=2)
+        disease_dengue = Disease.objects.create(name="Demam Berdarah", level_of_alertness=3)
+
+        loc_jakarta = Location.objects.create(
+            latitude=Decimal("1.000000"),
+            longitude=Decimal("120.000000"),
+            city="Jakarta",
+            province="DKI Jakarta",
+        )
+        loc_bandung = Location.objects.create(
+            latitude=Decimal("2.000000"),
+            longitude=Decimal("121.000000"),
+            city="Bandung",
+            province="Jawa Barat",
+        )
+
+        published_day_one = timezone.make_aware(datetime(2024, 1, 10, 10, 0))
+        published_day_two = timezone.make_aware(datetime(2024, 1, 12, 10, 0))
+        published_day_three = timezone.make_aware(datetime(2024, 1, 20, 10, 0))
+
+        case_flu = Case.objects.create(
+            gender="male",
+            age=30,
+            city="Jakarta",
+            status="biasa",
+            severity="hospitalisasi",
+            disease=disease_flu,
+            location=loc_jakarta,
+        )
+        case_dengue = Case.objects.create(
+            gender="female",
+            age=40,
+            city="Bandung",
+            status="bahaya",
+            severity="insiden",
+            disease=disease_dengue,
+            location=loc_bandung,
+        )
+        case_mortal = Case.objects.create(
+            gender="male",
+            age=55,
+            city="Jakarta",
+            status="katastropik",
+            severity="mortalitas",
+            disease=disease_dengue,
+            location=loc_jakarta,
+        )
+
+        News.objects.create(
+            portal="Portal Nasional",
+            title="National update",
+            type="Nasional",
+            content="National news content",
+            url="https://example.com/national",
+            author="Reporter 1",
+            date_published=published_day_one,
+            case=case_flu,
+        )
+        News.objects.create(
+            portal="Portal Lokal",
+            title="Local update",
+            type="Lokal",
+            content="Local news content",
+            url="https://example.com/local",
+            author="Reporter 2",
+            date_published=published_day_two,
+            case=case_dengue,
+        )
+        News.objects.create(
+            portal="Portal Kesehatan",
+            title="Healthcare update",
+            type="Kesehatan",
+            content="Healthcare news content",
+            url="https://example.com/health",
+            author="Reporter 3",
+            date_published=published_day_three,
+            case=case_mortal,
+        )
 
 
 class DownloadLogAPIViewTests(APITestCase):
@@ -35,6 +179,18 @@ class DownloadLogAPIViewTests(APITestCase):
         response = client.post(self.url, payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_logging_disabled_returns_accepted(self):
+        payload = {
+            "username": "KuratorA",
+            "chartType": "BarChart",
+            "timestamp": timezone.now().isoformat(),
+        }
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertFalse(response.data.get("logged", True))
+
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
     def test_logs_download_event(self):
         payload = {
             "username": "KuratorA",
@@ -82,6 +238,7 @@ class DownloadLogAPIViewTests(APITestCase):
         errors = response.data.get("errors", {})
         self.assertIn("timestamp", errors)
 
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
     def test_database_failure_returns_500(self):
         payload = {
             "username": "KuratorA",

--- a/curator_feature/urls.py
+++ b/curator_feature/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from curator_feature.views import ChartDataAPIView, DashboardDownloadEventAPIView, DownloadLogAPIView
+from curator_feature.views import ChartDataAPIView, DashboardDownloadEventAPIView, DownloadLogAPIView, ChartsSimpleView
 
 urlpatterns = [
     path("charts/data", ChartDataAPIView.as_view(), name="curator-charts-data"),
     path("download", DownloadLogAPIView.as_view(), name="curator-download-log"),
     path("downloads/log/", DashboardDownloadEventAPIView.as_view(), name="curator-dashboard-download-log"),
+    path("charts", ChartsSimpleView.as_view(), name="curator-charts-simple"),
 ]

--- a/curator_feature/urls.py
+++ b/curator_feature/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from curator_feature.views import DownloadLogAPIView, DashboardDownloadEventAPIView
+from curator_feature.views import ChartDataAPIView, DashboardDownloadEventAPIView, DownloadLogAPIView
 
 urlpatterns = [
+    path("charts/data", ChartDataAPIView.as_view(), name="curator-charts-data"),
     path("download", DownloadLogAPIView.as_view(), name="curator-download-log"),
     path("downloads/log/", DashboardDownloadEventAPIView.as_view(), name="curator-dashboard-download-log"),
 ]

--- a/curator_feature/views.py
+++ b/curator_feature/views.py
@@ -10,13 +10,86 @@ from pt_backend.authentication import APIKeyAuthentication
 
 from curator_feature.models import DashboardDownloadEvent
 from curator_feature.serializers import (
+    ChartDataFiltersSerializer,
     DownloadLogRequestSerializer,
     DownloadLogResponseSerializer,
     DashboardDownloadEventSerializer,
 )
-from curator_feature.services import DownloadLogService
+from curator_feature.services import ChartDataService, DownloadLogService
 
 logger = logging.getLogger(__name__)
+
+
+class ChartDataAPIView(APIView):
+    authentication_classes = [CustomJWTAuthentication]
+    permission_classes = [IsTokenAuthenticated]
+
+    request_serializer_class = ChartDataFiltersSerializer
+    service_class = ChartDataService
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.service = self.service_class()
+
+    def get(self, request, *args, **kwargs):
+        try:
+            payload = self.service.get_chart_data(filters=None)
+        except Exception:
+            logger.exception("Unable to retrieve chart data")
+            return Response(
+                {"message": "Failed to fetch chart data"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(payload, status=status.HTTP_200_OK)
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.request_serializer_class(data=request.data)
+        if not serializer.is_valid():
+            logger.debug("Invalid chart data filters: %s", serializer.errors)
+            return Response({"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        filters = self._build_filters(serializer.validated_data)
+        try:
+            payload = self.service.get_chart_data(filters=filters or None)
+        except Exception:
+            logger.exception("Unable to retrieve chart data with filters")
+            return Response(
+                {"message": "Failed to fetch chart data"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(payload, status=status.HTTP_200_OK)
+
+    def _build_filters(self, data):
+        filters = {}
+        diseases = data.get("diseases") or []
+        if diseases:
+            filters["disease"] = diseases
+
+        portals = data.get("portals") or []
+        if portals:
+            filters["portals"] = portals
+
+        level = data.get("level_of_alertness")
+        if level:
+            filters["disease_alertness"] = level
+
+        locations = data.get("locations") or {}
+        provinces = locations.get("provinces") or []
+        cities = locations.get("cities") or []
+        if provinces:
+            filters["provinces"] = provinces
+        if cities:
+            filters["cities"] = cities
+
+        start_date = data.get("start_date")
+        end_date = data.get("end_date")
+        if start_date or end_date:
+            filters["date_range"] = {
+                "start": start_date.isoformat() if start_date else None,
+                "end": end_date.isoformat() if end_date else None,
+            }
+
+        return filters
 
 
 class DownloadLogAPIView(APIView):
@@ -38,6 +111,13 @@ class DownloadLogAPIView(APIView):
             return Response({"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         payload = serializer.validated_data
+
+        if not getattr(settings, "ENABLE_DOWNLOAD_LOGGING", False):
+            return Response(
+                {"logged": False, "detail": "Download logging disabled"},
+                status=status.HTTP_202_ACCEPTED,
+            )
+
         try:
             log_entry = self.service.log_download(
                 username=payload["username"],

--- a/curator_feature/views.py
+++ b/curator_feature/views.py
@@ -20,6 +20,21 @@ from curator_feature.services import ChartDataService, DownloadLogService
 logger = logging.getLogger(__name__)
 
 
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+class ChartsSimpleView(APIView):
+    def get(self, request, *args, **kwargs):
+        from curator_feature.services import ChartDataService
+        service = ChartDataService()
+        try:
+            payload = service.get_chart_data()
+        except Exception:
+            logger.exception("Unable to retrieve chart data from pt_backend")
+            return Response({"message": "Failed to fetch chart data"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return Response(payload, status=status.HTTP_200_OK)
+
+
 class ChartDataAPIView(APIView):
     authentication_classes = [CustomJWTAuthentication]
     permission_classes = [IsTokenAuthenticated]


### PR DESCRIPTION
This merge delivers PBI 6 for data visualization and download. I added chart data APIs for the Curator Dashboard and a download logging API. ChartDataService builds clean payloads for severity age gender trend prevalence and news coverage. The GET returns default charts. The POST accepts filters for diseases portals alertness date range provinces and cities. It rejects an end date that is earlier than the start date. The response includes meta with generatedAt and a flag that shows if filters were used. Download logging is guarded by a setting. When off the endpoint returns accepted and does not write logs. When on it writes a log entry and handles database errors. Serializers now validate input and accept case insensitive choices. New tests cover auth happy path filters invalid dates and logging on and off. URLs added are /api/logs/charts/data and /api/logs/download and /api/logs/downloads/log and /api/logs/charts. This prepares the dashboard for curator use and makes data download reliable.