### PR TITLE
PBI 5 CURATOR DATA

### DIFF
--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -133,3 +133,33 @@ class CuratorCaseAPITests(TestCase):
         self.assertEqual(case.location.city, "Sukabumi")
         self.assertEqual(case.severity, "mortalitas")
 
+    def test_delete_case_and_cascade_news(self):
+            """DELETE removes Case and cascades News (depends on FK on_delete)."""
+            case = Case.objects.create(
+                id=uuid.uuid4(),
+                disease=self.disease_hb,
+                location=self.loc_palangka,
+                gender="P",
+                age=12,
+                city="Palangka Raya",
+                status="bahaya",
+                severity="insiden",
+            )
+            News.objects.create(
+                case=case,
+                portal="P",
+                title="T",
+                type="artikel",
+                content="C",
+                url="https://example.com/x",
+                author="A",
+                date_published=datetime(2024, 1, 23, tzinfo=timezone.utc),
+                img_url="",
+            )
+
+            self.as_curator()
+            res = self.client.delete(f"{CASES_BASE}{case.id}/")
+            self.assertEqual(res.status_code, 204)
+            self.assertFalse(Case.objects.filter(id=case.id).exists())
+            self.assertEqual(News.objects.filter(case_id=case.id).count(), 0)
+

--- a/curator_feature/views.py
+++ b/curator_feature/views.py
@@ -189,3 +189,15 @@ class CuratorCaseListCreateView(_CuratorBaseView, generics.ListCreateAPIView):
 
     def get_serializer_class(self):
         return CaseReadSerializer if self.request.method == "GET" else CaseWriteSerializer
+    
+class CuratorCaseDetailView(_CuratorBaseView, generics.RetrieveUpdateDestroyAPIView):
+    lookup_field = "id"
+    queryset = (
+        Case.objects.select_related("disease", "location")
+        .prefetch_related("news")
+        .order_by("-id")
+    )
+
+    def get_serializer_class(self):
+        # GET returns read serializer; PATCH/PUT use write serializer
+        return CaseReadSerializer if self.request.method == "GET" else CaseWriteSerializer

--- a/curator_feature/views.py
+++ b/curator_feature/views.py
@@ -19,3 +19,10 @@ class CuratorCaseListCreateView(_CuratorBaseView, generics.ListCreateAPIView):
 
     def get_serializer_class(self):
         return CaseReadSerializer if self.request.method == "GET" else CaseWriteSerializer
+
+class CuratorCaseDetailView(_CuratorBaseView, generics.RetrieveUpdateDestroyAPIView):
+    lookup_field = "id"
+    queryset = Case.objects.select_related("disease", "location").prefetch_related("news")
+
+    def get_serializer_class(self):
+        return CaseReadSerializer if self.request.method == "GET" else CaseWriteSerializer


### PR DESCRIPTION
Implements CuratorCaseDetailView on RetrieveUpdateDestroyAPIView with an optimized queryset (select_related(disease, location), prefetch_related(news)) and method-aware serializers, CaseReadSerializer for GET, CaseWriteSerializer for PATCH/PUT—to keep reads lean and writes strictly validated.

Adds test_delete_case_and_cascade_news to assert FK cascade semantics: deleting a Case returns 204, removes the record, and clears all related News. Net effect: cleaner API surface, faster queries, and no orphaned news artifacts.