### PR TITLE
Pbi 5 crud data curator

### DIFF
--- a/curator_feature/test_cases/__init__.py
+++ b/curator_feature/test_cases/__init__.py
@@ -1,0 +1,1 @@
+# This makes Django detect this folder as a test package

--- a/curator_feature/test_cases/test_case_mocking.py
+++ b/curator_feature/test_cases/test_case_mocking.py
@@ -1,0 +1,98 @@
+# tests/test_case_mocking.py
+
+from unittest.mock import patch, Mock
+from django.test import TestCase
+from rest_framework.test import APIClient
+from pt_backend.models import Case, Disease, Location, User
+from django.contrib.auth.hashers import make_password
+
+CASES_BASE = "/curator-feature/curator/cases/"
+
+class CuratorCaseMockTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        # Create a curator user (hash password to allow login if needed)
+        self.curator = User.objects.create(
+            name="Curator",
+            email="curator@example.com",
+            password=make_password("x"),
+        )
+        setattr(self.curator, "role", "CURATOR")
+        self.curator.save()
+        self.client.force_authenticate(self.curator)
+
+        # Seed data
+        self.disease = Disease.objects.create(name="DBD", level_of_alertness=3)
+        self.location = Location.objects.create(
+            city="Palangka Raya", province="Kalimantan Tengah",
+            latitude=-2.1, longitude=113.9
+        )
+
+    @patch("curator_feature.serializers.News.objects.create")
+    def test_create_case_when_news_creation_fails(self, mock_news_create):
+        """
+        ✅ Mock News failure — expect exception to be raised (no view changes needed)
+        """
+        mock_news_create.side_effect = Exception("DB write failed")
+
+        payload = {
+            "disease": "DBD",
+            "gender": "L",
+            "age": 10,
+            "city": "Palangka Raya",
+            "status": "bahaya",
+            "severity": "insiden",
+            "location": {"city": "Palangka Raya"},
+            "news": {
+                "portal": "Kompas",
+                "title": "Kasus",
+                "type": "artikel",
+                "content": "isi berita",
+                "url": "https://example.com",
+                "author": "Reporter",
+                "date_published": "2024-01-23T00:00:00Z",
+                "img_url": "",
+            },
+        }
+
+        # ✅ Expect serializer/view to raise an exception (since no error handling exists)
+        with self.assertRaises(Exception):
+            self.client.post(CASES_BASE, payload, format="json")
+
+        mock_news_create.assert_called_once()
+
+
+
+    @patch("curator_feature.serializers.Disease.objects.get")
+    def test_create_case_mock_disease_not_found(self, mock_disease_get):
+        """
+        ✅ MOCK to isolate serializer logic from actual database.
+        Simulate Disease lookup failure -> returns 400.
+        """
+        mock_disease_get.side_effect = Disease.DoesNotExist()
+
+        payload = {
+            "disease": "Unknown",
+            "gender": "L",
+            "age": 10,
+            "city": "Palangka Raya",
+            "status": "bahaya",
+            "severity": "insiden",
+            "location": {"city": "Palangka Raya"},
+            "news": {
+                "portal": "Kompas",
+                "title": "Kasus X",
+                "type": "artikel",
+                "content": "C",
+                "url": "https://example.com",
+                "author": "A",
+                "date_published": "2024-01-23T00:00:00Z",
+                "img_url": "",
+            },
+        }
+
+        response = self.client.post(CASES_BASE, payload, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        mock_disease_get.assert_called_once()

--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -1323,6 +1323,253 @@ class CuratorCaseAPITests(TestCase):
         self.assertEqual(res.status_code, 204)
         self.assertFalse(Case.objects.filter(id=case.id).exists())
         self.assertEqual(News.objects.filter(case_id=case.id).count(), 0)
+    
+    # NEGATIVE & EDGE CASES
+
+    def test_patch_update_news_upserts_when_absent_and_updates_when_present(self):
+        """PATCH first creates a News if none exists, then updates the latest on subsequent PATCH."""
+        case = Case.objects.create(
+            id=uuid.uuid4(),
+            disease=self.disease_hb,
+            location=self.loc_palangka,
+            gender="P",
+            age=12,
+            city="Palangka Raya",
+            status="biasa",
+            severity="insiden",
+        )
+        self.as_curator()
+        payload = {
+            "news": {
+                "portal": "Portal",
+                "title": "T",
+                "type": "artikel",
+                "content": "C",
+                "url": "https://example.com/x",
+                "author": "A",
+                "date_published": "2024-02-01T00:00:00Z",
+                "img_url": "",
+            }
+        }
+        # upsert create
+        res = self.client.patch(f"{CASES_BASE}{case.id}/", payload, format="json")
+        self.assertEqual(res.status_code, 200, res.data)
+        self.assertEqual(News.objects.filter(case=case).count(), 1)
+
+        # update latest
+        payload["news"]["title"] = "T2"
+        res2 = self.client.patch(f"{CASES_BASE}{case.id}/", payload, format="json")
+        self.assertEqual(res2.status_code, 200, res2.data)
+        self.assertEqual(News.objects.get(case=case).title, "T2")
+
+    def test_create_case_creates_new_location_when_not_found(self):
+        """Create succeeds and auto-creates new Location when not found (with full fields)."""
+        self.as_curator()
+        payload = {
+            "disease": "DBD",
+            "gender": "L",
+            "age": 10,
+            "city": "Kota Baru",
+            "status": "biasa",
+            "severity": "mortalitas",
+            "location": {
+                "city": "Kota Baru",
+                "province": "Kalimantan Selatan",
+                "latitude": -3.442300,
+                "longitude": 114.845500,
+            },
+            "news": {
+                "portal": "Portal",
+                "title": "Judul",
+                "type": "artikel",
+                "content": "Isi",
+                "url": "https://example.com/x",
+                "author": "Y",
+                "date_published": "2024-02-01T00:00:00Z",
+                "img_url": "",
+            },
+        }
+        res = self.client.post(CASES_BASE, payload, format="json")
+        self.assertEqual(res.status_code, 201, res.data)
+        case = Case.objects.get(id=res.data["id"])
+        self.assertEqual(case.location.city, "Kota Baru")
+        self.assertTrue(
+            Location.objects.filter(
+                city__iexact="Kota Baru", province__iexact="Kalimantan Selatan"
+            ).exists()
+        )
+
+    def test_list_and_retrieve_include_read_fields(self):
+        """List and Retrieve return expanded read fields (disease_name, location, news)."""
+        case = Case.objects.create(
+            id=uuid.uuid4(),
+            disease=self.disease_hb,
+            location=self.loc_palangka,
+            gender="P",
+            age=12,
+            city="Palangka Raya",
+            status="bahaya",
+            severity="insiden",
+        )
+        News.objects.create(
+            case=case,
+            portal="Kompas",
+            title="Kasus",
+            type="artikel",
+            content="x",
+            url="https://example.com/x",
+            author="y",
+            date_published=datetime(2024, 1, 23, tzinfo=timezone.utc),
+            img_url="",
+        )
+        self.as_curator()
+        res_list = self.client.get(CASES_BASE)
+        self.assertEqual(res_list.status_code, 200)
+        self.assertIn("disease_name", res_list.data[0])
+
+        res_detail = self.client.get(f"{CASES_BASE}{case.id}/")
+        self.assertEqual(res_detail.status_code, 200)
+        self.assertEqual(res_detail.data["disease_name"], "Hepatitis B")
+        self.assertEqual(len(res_detail.data["news"]), 1)
+
+    def test_create_case_ambiguous_city_needs_province(self):
+        """Ambiguous city w/o province -> 400 with helpful error."""
+        self.as_curator()
+        payload = {
+            "disease": "DBD",
+            "gender": "L",
+            "age": 9,
+            "city": "Sukabumi",
+            "status": "minimal",
+            "severity": "hospitalisasi",
+            "location": {"city": "Sukabumi"},
+            "news": {
+                "portal": "Portal",
+                "title": "A",
+                "type": "artikel",
+                "content": "B",
+                "url": "https://example.com/valid",
+                "author": "C",
+                "date_published": "2024-01-23T00:00:00Z",
+                "img_url": "",
+            },
+        }
+        res = self.client.post(CASES_BASE, payload, format="json")
+        self.assertEqual(res.status_code, 400, res.data)
+        self.assertIn("location", res.data)
+
+    def test_create_case_missing_fields_for_new_location(self):
+        """Location not found and missing province/lat/lon -> 400 with missing fields listed."""
+        self.as_curator()
+        payload = {
+            "disease": "DBD",
+            "gender": "L",
+            "age": 10,
+            "city": "Kota Fiktif",
+            "status": "katastropik",
+            "severity": "insiden",
+            "location": {"city": "Kota Fiktif"},
+            "news": {
+                "portal": "P",
+                "title": "T",
+                "type": "artikel",
+                "content": "C",
+                "url": "https://example.com/x",
+                "author": "A",
+                "date_published": "2024-02-01T00:00:00Z",
+                "img_url": "",
+            },
+        }
+        res = self.client.post(CASES_BASE, payload, format="json")
+        self.assertEqual(res.status_code, 400, res.data)
+        self.assertIn("location", res.data)
+
+    def test_create_case_disease_name_not_found(self):
+        """Disease name not found -> 400 with field error."""
+        self.as_curator()
+        payload = {
+            "disease": "NotExist",
+            "gender": "P",
+            "age": 11,
+            "city": "Palangka Raya",
+            "status": "bahaya",
+            "severity": "insiden",
+            "location": {"city": "Palangka Raya"},
+            "news": {
+                "portal": "Portal",
+                "title": "T",
+                "type": "artikel",
+                "content": "C",
+                "url": "https://example.com/x",
+                "author": "A",
+                "date_published": "2024-02-01T00:00:00Z",
+                "img_url": "",
+            },
+        }
+        res = self.client.post(CASES_BASE, payload, format="json")
+        self.assertEqual(res.status_code, 400, res.data)
+        self.assertIn("disease", res.data)
+
+    def test_create_case_invalid_status_or_severity(self):
+        """Invalid status/severity enums -> 400 with field errors."""
+        self.as_curator()
+        payload = {
+            "disease": "DBD",
+            "gender": "L",
+            "age": 10,
+            "city": "Palangka Raya",
+            "status": "wrongstatus",
+            "severity": "wrongseverity",
+            "location": {"city": "Palangka Raya"},
+            "news": {
+                "portal": "Portal",
+                "title": "T",
+                "type": "artikel",
+                "content": "C",
+                "url": "https://example.com/x",
+                "author": "A",
+                "date_published": "2024-02-01T00:00:00Z",
+                "img_url": "",
+            },
+        }
+        res = self.client.post(CASES_BASE, payload, format="json")
+        self.assertEqual(res.status_code, 400, res.data)
+        self.assertIn("status", res.data)
+        self.assertIn("severity", res.data)
+
+    def test_patch_ambiguous_city_requires_province(self):
+        """PATCH with ambiguous city and no province -> 400."""
+        case = Case.objects.create(
+            id=uuid.uuid4(),
+            disease=self.disease_hb,
+            location=self.loc_palangka,
+            gender="P",
+            age=12,
+            city="Palangka Raya",
+            status="minimal",
+            severity="insiden",
+        )
+        self.as_curator()
+        res = self.client.patch(
+            f"{CASES_BASE}{case.id}/",
+            {"location": {"city": "Sukabumi"}},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 400, res.data)
+        self.assertIn("location", res.data)
+
+    def test_auth_required(self):
+        """Anon access -> 401 on list."""
+        self.as_anon()
+        res = self.client.get(CASES_BASE)
+        self.assertEqual(res.status_code, 401)
+
+    def test_role_must_be_curator(self):
+        """Non-curator role -> 403 on list."""
+        self.as_other()
+        res = self.client.get(CASES_BASE)
+        self.assertEqual(res.status_code, 403)
+
 
 
 class DashboardDownloadAPIKeyAuthExtraTests(APITestCase):


### PR DESCRIPTION
This MR enhances the test coverage of the curator_feature module by adding:

Mock-based tests to isolate serializer behavior from real DB operations

Edge case and negative-path tests for case creation, update, and retrieval

Validation scenarios for disease lookup, ambiguous locations, invalid enums, and authentication/authorization

Tests for upsert logic in PATCH requests (create news if absent, update if exists)