### PR TITLE
Pbi 10 expert data visualization download

### DIFF
--- a/expert_user_feature/serializers.py
+++ b/expert_user_feature/serializers.py
@@ -1,4 +1,6 @@
 from rest_framework import serializers
+from curator_feature.models import DashboardDownloadEvent
+from curator_feature.serializers import CaseInsensitiveChoiceField
 from pt_backend.models import Case, Disease, Location, News
 
 
@@ -16,7 +18,8 @@ class CaseWriteSerializer(serializers.Serializer):
         location_data = validated_data.pop("location")
         news_data = validated_data.pop("news")
 
-        disease = Disease.objects.get(name=validated_data["disease"])
+        disease_name = validated_data.pop("disease")
+        disease = Disease.objects.get(name=disease_name)
 
         location, _ = Location.objects.get_or_create(
             city=location_data.get("city"),
@@ -36,3 +39,26 @@ class CaseReadSerializer(serializers.ModelSerializer):
     class Meta:
         model = Case
         fields = "__all__"
+
+
+class ExpertDashboardDownloadSerializer(serializers.Serializer):
+    """Serializer mirroring curator dashboard downloads but allowing CSV format."""
+
+    metric = CaseInsensitiveChoiceField(choices=DashboardDownloadEvent.Metric.choices)
+    file_format = CaseInsensitiveChoiceField(
+        choices=tuple(DashboardDownloadEvent.FileFormat.choices) + (("csv", "CSV"),)
+    )
+    filters = serializers.JSONField(required=False)
+    source = serializers.CharField(max_length=255, required=False, allow_blank=False, trim_whitespace=True)
+
+    def validate_filters(self, value):
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Filters must be an object.")
+        return value
+
+    def validate_source(self, value):
+        if not value:
+            raise serializers.ValidationError("Source may not be blank.")
+        return value

--- a/expert_user_feature/test_downloads.py
+++ b/expert_user_feature/test_downloads.py
@@ -1,0 +1,402 @@
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pantau_tular.test_settings")
+
+import uuid
+
+import django
+
+django.setup()
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient, APIRequestFactory
+
+from curator_feature.models import DashboardDownloadEvent
+from expert_user_feature.permissions import IsExpertUserRole, ReadOnlyOrExpert
+from expert_user_feature.serializers import CaseReadSerializer, CaseWriteSerializer, ExpertDashboardDownloadSerializer
+from expert_user_feature.views import ExpertCaseCreateView, ExpertDashboardCSVDownloadAPIView
+from pt_backend.models import Case, Disease, Location, News, User as PtUser
+
+
+LOG_URL = "/expert-feature/downloads/log/"
+CSV_URL = "/expert-feature/downloads/csv/"
+
+
+class ExpertDownloadAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = PtUser.objects.create(
+            name="Expert",
+            email="expert@example.com",
+            password="pwd",
+            role="EXP_USER",
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.disease_high = Disease.objects.create(name="DBD", level_of_alertness=3)
+        self.disease_low = Disease.objects.create(name="Flu", level_of_alertness=1)
+
+        self.location_jakarta = Location.objects.create(city="Jakarta", province="DKI Jakarta")
+        self.location_bandung = Location.objects.create(city="Bandung", province="Jawa Barat")
+
+        self.case_with_news = Case.objects.create(
+            disease=self.disease_high,
+            location=self.location_jakarta,
+            gender="P",
+            age=30,
+            city="Jakarta",
+            status="bahaya",
+            severity="insiden",
+        )
+        self.news_article = News.objects.create(
+            case=self.case_with_news,
+            portal="Portal A",
+            title="Berita Kasus",
+            type="artikel",
+            content="Isi berita",
+            url="https://example.com/a",
+            author="Reporter A",
+            date_published=timezone.make_aware(datetime(2024, 3, 10, 8, 0, 0)),
+            img_url="https://example.com/a.png",
+        )
+
+        self.case_no_news = Case.objects.create(
+            disease=self.disease_high,
+            location=self.location_jakarta,
+            gender="L",
+            age=45,
+            city="Jakarta",
+            status="biasa",
+            severity="hospitalisasi",
+        )
+
+        self.case_filtered_out = Case.objects.create(
+            disease=self.disease_low,
+            location=self.location_bandung,
+            gender="L",
+            age=19,
+            city="Bandung",
+            status="minimal",
+            severity="hospitalisasi",
+        )
+        News.objects.create(
+            case=self.case_filtered_out,
+            portal="Portal Z",
+            title="Berita Lain",
+            type="artikel",
+            content="Berita luar filter",
+            url="https://example.com/z",
+            author="Reporter Z",
+            date_published=timezone.make_aware(datetime(2023, 1, 5, 12, 0, 0)),
+            img_url="https://example.com/z.png",
+        )
+
+    def tearDown(self):
+        DashboardDownloadEvent.objects.all().delete()
+
+    def _filters_payload(self):
+        start = (self.news_article.date_published - timedelta(days=1)).date().isoformat()
+        end = (self.news_article.date_published + timedelta(days=1)).date().isoformat()
+        return {
+            "diseases": [self.disease_high.name],
+            "portals": ["Portal A"],
+            "level_of_alertness": self.disease_high.level_of_alertness,
+            "locations": {
+                "cities": [self.location_jakarta.city],
+                "provinces": [self.location_jakarta.province],
+            },
+            "start_date": start,
+            "end_date": end,
+        }
+
+    def test_download_log_returns_accepted_when_logging_disabled(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "png",
+            "source": "expert-dashboard",
+        }
+
+        response = self.client.post(LOG_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertFalse(response.data["logged"])
+        self.assertEqual(DashboardDownloadEvent.objects.count(), 0)
+
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
+    def test_download_log_creates_event_when_enabled(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "png",
+            "filters": self._filters_payload(),
+            "source": "expert-dashboard",
+        }
+
+        response = self.client.post(LOG_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue(response.data["logged"])
+        event = DashboardDownloadEvent.objects.get()
+        self.assertEqual(event.metric, "jumlah_kasus")
+        self.assertEqual(event.file_format, "png")
+        self.assertEqual(event.metadata["filters"]["diseases"], [self.disease_high.name])
+        self.assertEqual(event.metadata["source"], "expert-dashboard")
+
+    def test_download_log_returns_validation_errors(self):
+        response = self.client.post(LOG_URL, {"file_format": "png"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", response.data)
+
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
+    def test_download_log_handles_persistence_failure(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "png",
+            "source": "expert-dashboard",
+        }
+
+        with patch("expert_user_feature.views.DashboardDownloadEventService.log_event", side_effect=Exception("db failure")):
+            response = self.client.post(LOG_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data["message"], "Download logging failed")
+
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
+    def test_csv_download_returns_file_and_logs_event(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "csv",
+            "filters": self._filters_payload(),
+            "source": "expert-dashboard",
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertEqual(response["X-Download-Logged"], "true")
+        self.assertIn('attachment; filename="jumlah_kasus-export.csv"', response["Content-Disposition"])
+        csv_rows = response.content.decode("utf-8").splitlines()
+        self.assertEqual(len(csv_rows), 2)
+        data_row = csv_rows[1].split(",")
+        self.assertEqual(data_row[0], str(self.case_with_news.id))
+        self.assertEqual(data_row[9], "Portal A")
+        self.assertEqual(DashboardDownloadEvent.objects.count(), 1)
+
+    def test_csv_download_includes_blank_news_columns(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "filters": {
+                "diseases": [self.disease_high.name],
+                "locations": {"cities": [self.location_jakarta.city]},
+            },
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        csv_rows = response.content.decode("utf-8").splitlines()
+        no_news_row = next(row for row in csv_rows[1:] if row.startswith(str(self.case_no_news.id)))
+        columns = no_news_row.split(",")
+        self.assertTrue(all(value == "" for value in columns[9:]))
+        self.assertEqual(response["X-Download-Logged"], "false")
+
+    def test_csv_download_filters_outside_requests(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "csv",
+            "filters": self._filters_payload(),
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        csv_rows = response.content.decode("utf-8").splitlines()
+        ids_returned = {row.split(",")[0] for row in csv_rows[1:]}
+        self.assertIn(str(self.case_with_news.id), ids_returned)
+        self.assertNotIn(str(self.case_filtered_out.id), ids_returned)
+
+    def test_filtered_cases_handles_location_filters(self):
+        view = ExpertDashboardCSVDownloadAPIView()
+        filters = {
+            "diseases": [self.disease_high.name],
+            "locations": {
+                "provinces": [self.location_jakarta.province],
+                "cities": [self.location_jakarta.city],
+            },
+        }
+        qs = view._filtered_cases(filters)
+        self.assertIn(self.case_with_news, qs)
+
+    def test_filtered_cases_without_province(self):
+        view = ExpertDashboardCSVDownloadAPIView()
+        filters = {
+            "diseases": [self.disease_high.name],
+            "locations": {"cities": [self.location_jakarta.city]},
+        }
+        qs = view._filtered_cases(filters)
+        self.assertIn(self.case_with_news, qs)
+
+    def test_csv_download_rejects_non_csv_format(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "png",
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["message"], "Only CSV downloads are supported by this endpoint.")
+
+    def test_csv_download_invalid_filters_returns_error(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "filters": {
+                "start_date": "2024-04-10",
+                "end_date": "2024-04-01",
+            },
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("filters", response.data["errors"])
+
+    @override_settings(ENABLE_DOWNLOAD_LOGGING=True)
+    def test_csv_download_handles_logging_failure(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "file_format": "csv",
+        }
+
+        with patch("expert_user_feature.views.DashboardDownloadEventService.log_event", side_effect=Exception("db failure")):
+            response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data["message"], "Download logging failed")
+
+    def test_csv_download_defaults_file_format_when_missing(self):
+        payload = {
+            "metric": "jumlah_kasus",
+            "filters": {"diseases": [self.disease_high.name]},
+        }
+
+        response = self.client.post(CSV_URL, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        csv_rows = response.content.decode("utf-8").splitlines()
+        self.assertTrue(csv_rows[0].startswith("case_id"))
+
+
+class ExpertPermissionsTests(TestCase):
+    def test_is_expert_user_role_checks_role(self):
+        perm = IsExpertUserRole()
+        request = SimpleNamespace(user=SimpleNamespace(role="EXP_USER"))
+        self.assertTrue(perm.has_permission(request, None))
+
+        request = SimpleNamespace(user=SimpleNamespace(role="CURATOR"))
+        self.assertFalse(perm.has_permission(request, None))
+
+        request = SimpleNamespace(user=None)
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_read_only_or_expert(self):
+        perm = ReadOnlyOrExpert()
+
+        read_request = SimpleNamespace(method="GET", user=None)
+        self.assertTrue(perm.has_permission(read_request, None))
+
+        write_request = SimpleNamespace(method="POST", user=SimpleNamespace(id=None, role="EXP_USER"))
+        self.assertFalse(perm.has_permission(write_request, None))
+
+        valid_request = SimpleNamespace(method="POST", user=SimpleNamespace(id=1, role="EXP_USER"))
+        self.assertTrue(perm.has_permission(valid_request, None))
+
+
+class ExpertSerializerTests(TestCase):
+    def setUp(self):
+        self.disease = Disease.objects.create(name="Leptospirosis", level_of_alertness=2)
+
+    def test_case_write_serializer_creates_case_and_news(self):
+        payload = {
+            "disease": self.disease.name,
+            "gender": "L",
+            "age": 35,
+            "city": "Semarang",
+            "status": "biasa",
+            "severity": "hospitalisasi",
+            "location": {
+                "city": "Semarang",
+                "province": "Jawa Tengah",
+                "latitude": -6.9667,
+                "longitude": 110.4167,
+            },
+            "news": {
+                "portal": "Portal X",
+                "title": "Kasus Dilaporkan",
+                "type": "artikel",
+                "content": "Isi berita",
+                "url": "https://example.com/news",
+                "author": "Reporter X",
+                "date_published": timezone.now(),
+                "img_url": "",
+            },
+        }
+
+        serializer = CaseWriteSerializer(data=payload)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        case = serializer.save()
+
+        self.assertEqual(case.disease, self.disease)
+        self.assertEqual(case.location.city, "Semarang")
+        self.assertEqual(case.news.count(), 1)
+
+    def test_expert_dashboard_download_serializer_rejects_invalid_filters(self):
+        serializer = ExpertDashboardDownloadSerializer(
+            data={"metric": "jumlah_kasus", "file_format": "csv", "filters": "not-a-dict"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("filters", serializer.errors)
+
+    def test_expert_dashboard_download_serializer_validates_source(self):
+        serializer = ExpertDashboardDownloadSerializer(
+            data={"metric": "jumlah_kasus", "file_format": "csv", "source": ""}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("source", serializer.errors)
+
+    def test_expert_dashboard_download_serializer_allows_none_filters(self):
+        serializer = ExpertDashboardDownloadSerializer()
+        self.assertIsNone(serializer.validate_filters(None))
+
+    def test_expert_dashboard_download_serializer_returns_source(self):
+        serializer = ExpertDashboardDownloadSerializer()
+        self.assertEqual(serializer.validate_source("dashboard"), "dashboard")
+
+    def test_expert_dashboard_download_serializer_full_validation(self):
+        serializer = ExpertDashboardDownloadSerializer(
+            data={"metric": "jumlah_kasus", "file_format": "csv", "source": "dashboard"}
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["source"], "dashboard")
+
+
+class ExpertViewSmokeTests(SimpleTestCase):
+    def test_get_serializer_class_returns_read_on_get(self):
+        view = ExpertCaseCreateView()
+        request = APIRequestFactory().get("/expert-feature/experts/cases/")
+        view.request = request
+        serializer_class = view.get_serializer_class()
+        self.assertIs(serializer_class, CaseReadSerializer)
+
+    def test_placeholder_endpoint_returns_200(self):
+        client = APIClient()
+        response = client.get("/expert-feature/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.content)

--- a/expert_user_feature/urls.py
+++ b/expert_user_feature/urls.py
@@ -1,9 +1,13 @@
-from django.urls import path
 from django.http import HttpResponse
+from django.urls import path
+
+from .views import ExpertDashboardCSVDownloadAPIView, ExpertDashboardDownloadLogAPIView
 
 def feature_placeholder(request):
     return HttpResponse("Expert User Feature Placeholder")
 
 urlpatterns = [
     path("", feature_placeholder, name="expert-feature-placeholder"),
+    path("downloads/log/", ExpertDashboardDownloadLogAPIView.as_view(), name="expert-dashboard-download-log"),
+    path("downloads/csv/", ExpertDashboardCSVDownloadAPIView.as_view(), name="expert-dashboard-download-csv"),
 ]

--- a/expert_user_feature/views.py
+++ b/expert_user_feature/views.py
@@ -1,7 +1,31 @@
-from rest_framework import generics
+import csv
+import io
+import logging
+from datetime import datetime, time
+from typing import Iterable, Optional, Tuple
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.utils import timezone
+from rest_framework import generics, status
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from curator_feature.models import DashboardDownloadEvent
+from curator_feature.serializers import ChartDataFiltersSerializer, DashboardDownloadEventSerializer
+from curator_feature.services import DashboardDownloadEventService
+from curator_feature.value_objects import ClientMetadata
 from pt_backend.models import Case
+
 from .views_base import ExpertBaseView
-from .serializers import CaseWriteSerializer, CaseReadSerializer
+from .serializers import (
+    CaseWriteSerializer,
+    CaseReadSerializer,
+    ExpertDashboardDownloadSerializer,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class ExpertCaseCreateView(ExpertBaseView, generics.CreateAPIView):
@@ -9,3 +33,246 @@ class ExpertCaseCreateView(ExpertBaseView, generics.CreateAPIView):
 
     def get_serializer_class(self):
         return CaseWriteSerializer if self.request.method == "POST" else CaseReadSerializer
+
+
+class ExpertDownloadMixin:
+    """Shared helpers for expert dashboard download related endpoints."""
+
+    filters_serializer_class = ChartDataFiltersSerializer
+    event_service_class = DashboardDownloadEventService
+    default_serializer_class = DashboardDownloadEventSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.event_service = self.event_service_class()
+
+    def _should_log(self) -> bool:
+        return bool(getattr(settings, "ENABLE_DOWNLOAD_LOGGING", False))
+
+    def _validate_payload(self, data) -> Tuple[dict, dict]:
+        serializer_class = getattr(self, "download_serializer_class", self.default_serializer_class)
+        serializer = serializer_class(data=data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except ValidationError as exc:
+            raise ValidationError(exc.detail) from exc
+
+        payload = serializer.validated_data
+        filters_payload = payload.get("filters") or {}
+        if filters_payload:
+            filters_serializer = self.filters_serializer_class(data=filters_payload)
+            try:
+                filters_serializer.is_valid(raise_exception=True)
+            except ValidationError as exc:
+                raise ValidationError({"filters": exc.detail}) from exc
+            filters_data = filters_serializer.validated_data
+        else:
+            filters_data = {}
+
+        return payload, filters_data
+
+    def _log_event(self, request, payload: dict):
+        if not self._should_log():
+            return False, None
+
+        client_metadata = ClientMetadata.from_request(request)
+        try:
+            event = self.event_service.log_event(
+                metric=payload["metric"],
+                file_format=payload["file_format"],
+                filters=payload.get("filters"),
+                source=payload.get("source"),
+                client=client_metadata,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to persist expert download event metric=%s format=%s",
+                payload.get("metric"),
+                payload.get("file_format"),
+            )
+            raise
+
+        return True, event
+
+    def _date_range_bounds(self, filters: dict) -> Tuple[Optional[datetime], Optional[datetime]]:
+        start = filters.get("start_date")
+        end = filters.get("end_date")
+        tz = timezone.get_current_timezone()
+
+        start_bound = None
+        if start:
+            start_bound = timezone.make_aware(datetime.combine(start, time.min), timezone=tz)
+
+        end_bound = None
+        if end:
+            end_bound = timezone.make_aware(datetime.combine(end, time.max), timezone=tz)
+
+        return start_bound, end_bound
+
+    def _filtered_cases(self, filters: dict) -> Iterable[Case]:
+        qs = Case.objects.select_related("disease", "location").prefetch_related("news")
+
+        diseases = filters.get("diseases")
+        if diseases:
+            qs = qs.filter(disease__name__in=diseases)
+
+        portals = filters.get("portals")
+        if portals:
+            qs = qs.filter(news__portal__in=portals)
+
+        alertness = filters.get("level_of_alertness")
+        if alertness:
+            qs = qs.filter(disease__level_of_alertness=alertness)
+
+        locations = filters.get("locations") or {}
+
+        provinces = locations.get("provinces")
+        if provinces:
+            qs = qs.filter(location__province__in=provinces)
+
+        cities = locations.get("cities")
+        if cities:
+            qs = qs.filter(location__city__in=cities)
+
+        start_bound, end_bound = self._date_range_bounds(filters)
+        if start_bound:
+            qs = qs.filter(news__date_published__gte=start_bound)
+        if end_bound:
+            qs = qs.filter(news__date_published__lte=end_bound)
+
+        return qs.distinct()
+
+    def _render_cases_csv(self, cases: Iterable[Case]) -> str:
+        header = [
+            "case_id",
+            "disease",
+            "level_of_alertness",
+            "severity",
+            "status",
+            "gender",
+            "age",
+            "city",
+            "province",
+            "news_portal",
+            "news_title",
+            "news_type",
+            "news_author",
+            "news_date_published",
+            "news_url",
+            "news_img_url",
+        ]
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(header)
+
+        for case in cases:
+            news_items = list(case.news.all())
+            if not news_items:
+                writer.writerow(self._case_row(case))
+                continue
+
+            for article in news_items:
+                writer.writerow(self._case_row(case, article))
+
+        return buffer.getvalue()
+
+    def _case_row(self, case: Case, article=None):
+        disease_name = getattr(case.disease, "name", "")
+        alertness = getattr(case.disease, "level_of_alertness", "")
+        location = getattr(case, "location", None)
+        province = getattr(location, "province", "") if location else ""
+
+        base = [
+            str(case.id),
+            disease_name,
+            alertness,
+            case.severity,
+            case.status,
+            case.gender,
+            case.age,
+            case.city,
+            province,
+        ]
+
+        if not article:
+            base.extend(["", "", "", "", "", "", ""])
+            return base
+
+        base.extend(
+            [
+                article.portal,
+                article.title,
+                article.type,
+                article.author,
+                article.date_published.isoformat(),
+                article.url,
+                article.img_url,
+            ]
+        )
+        return base
+
+
+class ExpertDashboardDownloadLogAPIView(ExpertBaseView, ExpertDownloadMixin, APIView):
+    """Mirror curator download logging workflow for expert users."""
+
+    def post(self, request, *args, **kwargs):
+        try:
+            payload, _ = self._validate_payload(request.data)
+        except ValidationError as exc:
+            return Response({"errors": exc.detail}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            logged, event = self._log_event(request, payload)
+        except Exception:
+            return Response(
+                {"message": "Download logging failed"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        if not logged:
+            return Response(
+                {"logged": False, "detail": "Download logging disabled"},
+                status=status.HTTP_202_ACCEPTED,
+            )
+
+        return Response({"id": event.id, "logged": True}, status=status.HTTP_201_CREATED)
+
+
+class ExpertDashboardCSVDownloadAPIView(ExpertBaseView, ExpertDownloadMixin, APIView):
+    """Provide CSV downloads for expert dashboard while logging the event."""
+
+    download_serializer_class = ExpertDashboardDownloadSerializer
+
+    def post(self, request, *args, **kwargs):
+        data = request.data.copy()
+        if "file_format" not in data:
+            data["file_format"] = "csv"
+
+        try:
+            payload, filters = self._validate_payload(data)
+        except ValidationError as exc:
+            return Response({"errors": exc.detail}, status=status.HTTP_400_BAD_REQUEST)
+
+        if payload["file_format"] != "csv":
+            return Response(
+                {"message": "Only CSV downloads are supported by this endpoint."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            logged, _ = self._log_event(request, payload)
+        except Exception:
+            return Response(
+                {"message": "Download logging failed"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        cases = self._filtered_cases(filters)
+        csv_content = self._render_cases_csv(cases)
+
+        response = HttpResponse(csv_content, content_type="text/csv")
+        filename = f"{payload.get('metric') or 'dashboard'}-export.csv"
+        response["Content-Disposition"] = f'attachment; filename=\"{filename}\"'
+        response["X-Download-Logged"] = "true" if logged else "false"
+        return response


### PR DESCRIPTION
Add expert dashboard download feature. This change adds CSV data export and keeps the current image download with html2canvas. It reuses the same backend logic from curator_feature and does not change any visualization. Two endpoints are added at /expert-feature/downloads/log/ and /expert-feature/downloads/csv/. Logging uses the existing DashboardDownloadEvent when logging is enabled and returns accepted when disabled. The CSV includes case fields and optional news fields. No files were deleted. Existing code is kept and new code is added.