### PR TITLE
Integrate Reusable Time-Window Parsing and DateRangeFilter Resolver

### DIFF
--- a/pt_backend/filter/date_range_filter.py
+++ b/pt_backend/filter/date_range_filter.py
@@ -1,11 +1,38 @@
-from datetime import datetime
+from datetime import datetime, timedelta, tzinfo
+from typing import Dict, Optional, Tuple, Union
+
 import pytz
 from django.db.models import Q
-from typing import Dict, Optional
+from django.utils.dateparse import parse_datetime as django_parse_datetime
+from pytz import UnknownTimeZoneError
+
 
 class DateRangeFilter:
     DEFAULT_START_KEY = "start_date"
     DEFAULT_END_KEY = "end_date"
+    DEFAULT_PERIOD_KEY = "period"
+    DEFAULT_TZ_KEY = "timezone"
+
+    PERIOD_UNITS = {
+        "m": "minutes",
+        "min": "minutes",
+        "mins": "minutes",
+        "minute": "minutes",
+        "minutes": "minutes",
+        "h": "hours",
+        "hr": "hours",
+        "hrs": "hours",
+        "hour": "hours",
+        "hours": "hours",
+        "d": "days",
+        "day": "days",
+        "days": "days",
+        "w": "weeks",
+        "wk": "weeks",
+        "wks": "weeks",
+        "week": "weeks",
+        "weeks": "weeks",
+    }
 
     def apply(self, data: Dict) -> Q:
         time_window = self.build_time_window(
@@ -27,11 +54,19 @@ class DateRangeFilter:
         end_key: str = DEFAULT_END_KEY,
         timezone=None,
         null_guard_field: Optional[str] = None,
+        period_key: str = DEFAULT_PERIOD_KEY,
+        tz_key: str = DEFAULT_TZ_KEY,
+        now: Optional[datetime] = None,
     ) -> Optional[Q]:
-        tz = timezone or pytz.UTC
-
-        start_date = cls.parse_datetime(data.get(start_key), tz)
-        end_date = cls.parse_datetime(data.get(end_key), tz)
+        start_date, end_date = cls.resolve_time_window(
+            data,
+            start_key=start_key,
+            end_key=end_key,
+            period_key=period_key,
+            tz_key=tz_key,
+            timezone=timezone,
+            now=now,
+        )
 
         if start_date and end_date:
             time_window = Q(**{f"{field}__range": [start_date, end_date]})
@@ -47,20 +82,153 @@ class DateRangeFilter:
 
         return time_window
 
-    @staticmethod
-    def parse_datetime(date_str: Optional[str], timezone) -> Optional[datetime]:
-        if not date_str:  # Handle None case
-            return None
-        
-        formats = [
-            "%Y-%m-%dT%H:%M:%S.%fZ",  # ISO 8601 dengan milidetik
-            "%Y-%m-%dT%H:%M:%SZ",      # ISO 8601 tanpa milidetik
-            "%Y-%m-%d %H:%M:%S",       # Format biasa dengan spasi
-        ]
-        for fmt in formats:
-            try:
-                return datetime.strptime(date_str, fmt).replace(tzinfo=timezone)
-            except ValueError:
-                continue
-        return None   
+    @classmethod
+    def resolve_time_window(
+        cls,
+        data: Dict,
+        *,
+        start_key: str = DEFAULT_START_KEY,
+        end_key: str = DEFAULT_END_KEY,
+        period_key: str = DEFAULT_PERIOD_KEY,
+        tz_key: str = DEFAULT_TZ_KEY,
+        timezone=None,
+        now: Optional[datetime] = None,
+    ) -> Tuple[Optional[datetime], Optional[datetime]]:
+        fallback_tz = timezone or pytz.UTC
+        tz = cls.resolve_timezone(data.get(tz_key), fallback_tz)
 
+        start_raw = data.get(start_key)
+        end_raw = data.get(end_key)
+        period_raw = data.get(period_key)
+
+        start_date = cls.parse_datetime(start_raw, tz)
+        end_date = cls.parse_datetime(end_raw, tz)
+        period_delta = cls.parse_period(period_raw) if period_raw else None
+
+        if period_delta:
+            start_date, end_date = cls.apply_period(
+                start_date=start_date,
+                end_date=end_date,
+                period=period_delta,
+                tz=tz,
+                now=now,
+            )
+
+        start_utc = cls.normalize_to_utc(start_date) if start_date else None
+        end_utc = cls.normalize_to_utc(end_date) if end_date else None
+
+        if start_utc and end_utc and start_utc > end_utc:
+            return None, None
+
+        return start_utc, end_utc
+
+    @staticmethod
+    def resolve_timezone(
+        tz_identifier: Optional[Union[str, tzinfo]],
+        default_tz,
+    ):
+        if isinstance(tz_identifier, str):
+            try:
+                return pytz.timezone(tz_identifier)
+            except UnknownTimeZoneError:
+                return default_tz
+        if hasattr(tz_identifier, "utcoffset"):
+            return tz_identifier
+        return default_tz
+
+    @classmethod
+    def parse_datetime(cls, date_str: Optional[str], tz) -> Optional[datetime]:
+        if not date_str:
+            return None
+
+        dt = django_parse_datetime(date_str)
+        if dt is None:
+            formats = [
+                "%Y-%m-%dT%H:%M:%S.%fZ",
+                "%Y-%m-%dT%H:%M:%SZ",
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d",
+            ]
+            for fmt in formats:
+                try:
+                    dt = datetime.strptime(date_str, fmt)
+                    break
+                except ValueError:
+                    continue
+
+        if dt is None:
+            return None
+
+        if dt.tzinfo is None:
+            if hasattr(tz, "localize"):
+                dt = tz.localize(dt)  # type: ignore[attr-defined]
+            else:
+                dt = dt.replace(tzinfo=tz)
+        else:
+            dt = dt.astimezone(tz)
+
+        return dt
+
+    @classmethod
+    def apply_period(
+        cls,
+        *,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        period: timedelta,
+        tz,
+        now: Optional[datetime] = None,
+    ) -> Tuple[Optional[datetime], Optional[datetime]]:
+        if period <= timedelta(0):
+            return start_date, end_date
+
+        reference_now = cls.ensure_timezone(now, tz) if now else datetime.now(tz)
+
+        if start_date and not end_date:
+            end_date = start_date + period
+        elif end_date and not start_date:
+            start_date = end_date - period
+        elif not start_date and not end_date:
+            end_date = reference_now
+            start_date = reference_now - period
+        return start_date, end_date
+
+    @staticmethod
+    def ensure_timezone(dt: Optional[datetime], tz):
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            if hasattr(tz, "localize"):
+                return tz.localize(dt)  # type: ignore[attr-defined]
+            return dt.replace(tzinfo=tz)
+        return dt.astimezone(tz)
+
+    @staticmethod
+    def normalize_to_utc(dt: datetime) -> datetime:
+        return dt.astimezone(pytz.UTC)
+
+    @classmethod
+    def parse_period(cls, period: Union[str, Dict[str, Union[int, str]]]) -> Optional[timedelta]:
+        if isinstance(period, dict):
+            value = period.get("value")
+            unit = period.get("unit")
+            if isinstance(value, int) and isinstance(unit, str):
+                unit_key = cls.PERIOD_UNITS.get(unit.lower())
+                if unit_key:
+                    return timedelta(**{unit_key: value})
+            return None
+
+        if isinstance(period, str):
+            period = period.strip()
+            if not period:
+                return None
+            if period.isdigit():
+                # Default to days if only a number is provided.
+                return timedelta(days=int(period))
+            for suffix in sorted(cls.PERIOD_UNITS, key=len, reverse=True):
+                if period.lower().endswith(suffix):
+                    value_part = period[: -len(suffix)].strip()
+                    if value_part.isdigit():
+                        unit_key = cls.PERIOD_UNITS[suffix]
+                        return timedelta(**{unit_key: int(value_part)})
+        return None

--- a/pt_backend/filter/date_range_filter.py
+++ b/pt_backend/filter/date_range_filter.py
@@ -4,22 +4,51 @@ from django.db.models import Q
 from typing import Dict, Optional
 
 class DateRangeFilter:
-    def apply(self, data: Dict) -> Q:
-        utc = pytz.UTC
+    DEFAULT_START_KEY = "start_date"
+    DEFAULT_END_KEY = "end_date"
 
-        start_date = self.parse_datetime(data.get("start_date"), utc)
-        end_date = self.parse_datetime(data.get("end_date"), utc)
+    def apply(self, data: Dict) -> Q:
+        time_window = self.build_time_window(
+            field="news__date_published",
+            data=data,
+            null_guard_field="news",
+        )
+        if time_window is not None:
+            return time_window
+        return Q()
+
+    @classmethod
+    def build_time_window(
+        cls,
+        field: str,
+        data: Dict,
+        *,
+        start_key: str = DEFAULT_START_KEY,
+        end_key: str = DEFAULT_END_KEY,
+        timezone=None,
+        null_guard_field: Optional[str] = None,
+    ) -> Optional[Q]:
+        tz = timezone or pytz.UTC
+
+        start_date = cls.parse_datetime(data.get(start_key), tz)
+        end_date = cls.parse_datetime(data.get(end_key), tz)
 
         if start_date and end_date:
-            return Q(news__date_published__range=[start_date, end_date]) & Q(news__isnull=False)
+            time_window = Q(**{f"{field}__range": [start_date, end_date]})
         elif start_date:
-            return Q(news__date_published__gte=start_date) & Q(news__isnull=False)
+            time_window = Q(**{f"{field}__gte": start_date})
         elif end_date:
-            return Q(news__date_published__lte=end_date) & Q(news__isnull=False)
+            time_window = Q(**{f"{field}__lte": end_date})
         else:
-            return Q()
+            return None
 
-    def parse_datetime(self, date_str: Optional[str], timezone) -> Optional[datetime]:
+        if null_guard_field:
+            time_window &= Q(**{f"{null_guard_field}__isnull": False})
+
+        return time_window
+
+    @staticmethod
+    def parse_datetime(date_str: Optional[str], timezone) -> Optional[datetime]:
         if not date_str:  # Handle None case
             return None
         

--- a/pt_backend/filter/service.py
+++ b/pt_backend/filter/service.py
@@ -1,5 +1,5 @@
 from django.db.models import Q, QuerySet
-from typing import Dict
+from typing import Dict, Optional
 from pt_backend.models import Case
 from .disease_filter import DiseaseFilter
 from .location_filter import LocationFilter
@@ -9,12 +9,13 @@ from .date_range_filter import DateRangeFilter
 
 class CaseFilterService:
     def __init__(self):
+        self.date_range_filter = DateRangeFilter()
         self.filters = [
             DiseaseFilter(),
             LocationFilter(),
             AlertnessFilter(),
             PortalFilter(),
-            DateRangeFilter()
+            self.date_range_filter,
         ]
 
     def filter_cases(self, data: Dict) -> QuerySet:
@@ -37,4 +38,23 @@ class CaseFilterService:
             .filter(query)
             .values('id', 'location__longitude', 'location__latitude', 'city', 'location__province', 'severity')
             .distinct()
+        )
+
+    @staticmethod
+    def time_window(
+        data: Dict,
+        *,
+        field: str,
+        start_key: str = DateRangeFilter.DEFAULT_START_KEY,
+        end_key: str = DateRangeFilter.DEFAULT_END_KEY,
+        timezone=None,
+        null_guard_field: Optional[str] = None,
+    ) -> Optional[Q]:
+        return DateRangeFilter.build_time_window(
+            field=field,
+            data=data,
+            start_key=start_key,
+            end_key=end_key,
+            timezone=timezone,
+            null_guard_field=null_guard_field,
         )

--- a/pt_backend/filter/service.py
+++ b/pt_backend/filter/service.py
@@ -1,5 +1,7 @@
+from datetime import datetime
+from typing import Dict, Optional, Tuple
+
 from django.db.models import Q, QuerySet
-from typing import Dict, Optional
 from pt_backend.models import Case
 from .disease_filter import DiseaseFilter
 from .location_filter import LocationFilter
@@ -49,6 +51,9 @@ class CaseFilterService:
         end_key: str = DateRangeFilter.DEFAULT_END_KEY,
         timezone=None,
         null_guard_field: Optional[str] = None,
+        period_key: str = DateRangeFilter.DEFAULT_PERIOD_KEY,
+        tz_key: str = DateRangeFilter.DEFAULT_TZ_KEY,
+        now: Optional[datetime] = None,
     ) -> Optional[Q]:
         return DateRangeFilter.build_time_window(
             field=field,
@@ -57,4 +62,28 @@ class CaseFilterService:
             end_key=end_key,
             timezone=timezone,
             null_guard_field=null_guard_field,
+            period_key=period_key,
+            tz_key=tz_key,
+            now=now,
+        )
+
+    @staticmethod
+    def resolve_time_window(
+        data: Dict,
+        *,
+        start_key: str = DateRangeFilter.DEFAULT_START_KEY,
+        end_key: str = DateRangeFilter.DEFAULT_END_KEY,
+        period_key: str = DateRangeFilter.DEFAULT_PERIOD_KEY,
+        tz_key: str = DateRangeFilter.DEFAULT_TZ_KEY,
+        timezone=None,
+        now: Optional[datetime] = None,
+    ) -> Tuple[Optional[datetime], Optional[datetime]]:
+        return DateRangeFilter.resolve_time_window(
+            data,
+            start_key=start_key,
+            end_key=end_key,
+            period_key=period_key,
+            tz_key=tz_key,
+            timezone=timezone,
+            now=now,
         )

--- a/pt_backend/filter/service.py
+++ b/pt_backend/filter/service.py
@@ -1,13 +1,16 @@
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 from django.db.models import Q, QuerySet
+from django.http import QueryDict
 from pt_backend.models import Case
 from .disease_filter import DiseaseFilter
 from .location_filter import LocationFilter
 from .alertness_filter import AlertnessFilter
 from .portal_filter import PortalFilter
 from .date_range_filter import DateRangeFilter
+
 
 class CaseFilterService:
     def __init__(self):
@@ -87,3 +90,131 @@ class CaseFilterService:
             timezone=timezone,
             now=now,
         )
+
+    @classmethod
+    def parse_time_params(
+        cls,
+        params: Union[Mapping[str, Any], QueryDict, Dict[str, Any]],
+        *,
+        start_key: str = DateRangeFilter.DEFAULT_START_KEY,
+        end_key: str = DateRangeFilter.DEFAULT_END_KEY,
+        period_key: str = DateRangeFilter.DEFAULT_PERIOD_KEY,
+        tz_key: str = DateRangeFilter.DEFAULT_TZ_KEY,
+        timezone=None,
+        now: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        raw_values, start_dt, end_dt = cls._resolve_from_params(
+            params,
+            start_key=start_key,
+            end_key=end_key,
+            period_key=period_key,
+            tz_key=tz_key,
+            timezone=timezone,
+            now=now,
+        )
+
+        payload: Dict[str, Any] = {}
+        if start_dt:
+            payload[start_key] = start_dt.isoformat()
+        if end_dt:
+            payload[end_key] = end_dt.isoformat()
+
+        if raw_values.get(tz_key):
+            payload[tz_key] = raw_values[tz_key]
+        if raw_values.get(period_key):
+            payload[period_key] = raw_values[period_key]
+
+        return payload
+
+    @classmethod
+    def parse_time_range(
+        cls,
+        params: Union[Mapping[str, Any], QueryDict, Dict[str, Any]],
+        *,
+        start_key: str = DateRangeFilter.DEFAULT_START_KEY,
+        end_key: str = DateRangeFilter.DEFAULT_END_KEY,
+        period_key: str = DateRangeFilter.DEFAULT_PERIOD_KEY,
+        tz_key: str = DateRangeFilter.DEFAULT_TZ_KEY,
+        timezone=None,
+        now: Optional[datetime] = None,
+        return_type: str = "dict",
+    ) -> Optional[Union[Dict[str, Optional[datetime]], Tuple[Optional[datetime], Optional[datetime]]]]:
+        _, start_dt, end_dt = cls._resolve_from_params(
+            params,
+            start_key=start_key,
+            end_key=end_key,
+            period_key=period_key,
+            tz_key=tz_key,
+            timezone=timezone,
+            now=now,
+        )
+
+        if not start_dt and not end_dt:
+            return None
+
+        if return_type == "tuple":
+            return start_dt, end_dt
+
+        return {
+            "start": start_dt,
+            "end": end_dt,
+        }
+
+    @classmethod
+    def _resolve_from_params(
+        cls,
+        params: Union[Mapping[str, Any], QueryDict, Dict[str, Any]],
+        *,
+        start_key: str,
+        end_key: str,
+        period_key: str,
+        tz_key: str,
+        timezone,
+        now: Optional[datetime],
+    ) -> Tuple[Dict[str, Any], Optional[datetime], Optional[datetime]]:
+        raw_values = {
+            start_key: cls._extract_param_value(params, start_key),
+            end_key: cls._extract_param_value(params, end_key),
+            period_key: cls._extract_param_value(params, period_key),
+            tz_key: cls._extract_param_value(params, tz_key),
+        }
+
+        start_dt, end_dt = cls.resolve_time_window(
+            raw_values,
+            start_key=start_key,
+            end_key=end_key,
+            period_key=period_key,
+            tz_key=tz_key,
+            timezone=timezone,
+            now=now,
+        )
+
+        return raw_values, start_dt, end_dt
+
+    @staticmethod
+    def _extract_param_value(
+        params: Union[Mapping[str, Any], QueryDict, Dict[str, Any]],
+        key: str,
+    ) -> Any:
+        if not params or key is None:
+            return None
+
+        if isinstance(params, QueryDict):
+            values = params.getlist(key)
+            return CaseFilterService._first_non_empty(values)
+
+        if hasattr(params, "get"):
+            value = params.get(key)
+        else:
+            value = getattr(params, key, None)
+
+        return CaseFilterService._first_non_empty(value)
+
+    @staticmethod
+    def _first_non_empty(value: Any) -> Any:
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if item not in (None, ""):
+                    return item
+            return None
+        return value

--- a/pt_backend/tests/location_severity/test_severity_filtering_views.py
+++ b/pt_backend/tests/location_severity/test_severity_filtering_views.py
@@ -6,6 +6,8 @@ from pt_backend.authentication import APIKeyAuthentication
 from pt_backend.services import SeverityFilteringService
 from pt_backend.models import Location
 from rest_framework import status
+from datetime import datetime
+import pytz
 
 
 class SeverityFilteringStatsPostViewTests(TestCase):
@@ -160,7 +162,10 @@ class SeverityFilteringStatsPostViewTests(TestCase):
             cities=None,
             news_portals=None,
             alert_levels=None,
-            date_range=("2023-01-01", "2023-12-31")
+            date_range=(
+                datetime(2023, 1, 1, tzinfo=pytz.UTC),
+                datetime(2023, 12, 31, tzinfo=pytz.UTC),
+            )
         )
     
     @patch.object(APIKeyAuthentication, 'authenticate', return_value=None)
@@ -197,7 +202,10 @@ class SeverityFilteringStatsPostViewTests(TestCase):
             cities=["Jakarta"],
             news_portals=["Kompas"],
             alert_levels=3,
-            date_range=("2023-01-01", "2023-12-31")
+            date_range=(
+                datetime(2023, 1, 1, tzinfo=pytz.UTC),
+                datetime(2023, 12, 31, tzinfo=pytz.UTC),
+            )
         )
     
     @patch.object(APIKeyAuthentication, 'authenticate', return_value=None)

--- a/pt_backend/tests/test_filters.py
+++ b/pt_backend/tests/test_filters.py
@@ -374,6 +374,24 @@ class CaseFilterServiceTest(TestCase):
         self.assertEqual(start, fixed_now - timedelta(days=1))
         self.assertEqual(end, fixed_now)
 
+    def test_parse_time_params_with_period(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': '1d'}
+        result = CaseFilterService.parse_time_params(data, now=fixed_now)
+        self.assertEqual(
+            result['start_date'],
+            (fixed_now - timedelta(days=1)).isoformat()
+        )
+        self.assertEqual(result['end_date'], fixed_now.isoformat())
+        self.assertEqual(result['period'], '1d')
+
+    def test_parse_time_range_as_tuple(self):
+        data = {'start_date': '2024-01-01T00:00:00', 'timezone': 'Asia/Jakarta'}
+        start, end = CaseFilterService.parse_time_range(data, return_type="tuple")
+        expected_start = pytz.timezone('Asia/Jakarta').localize(datetime(2024, 1, 1)).astimezone(pytz.UTC)
+        self.assertEqual(start, expected_start)
+        self.assertIsNone(end)
+
     def test_filter_cases_with_none_returning_filter(self):
         mock_filter = Mock()
         mock_filter.apply.return_value = None

--- a/pt_backend/tests/test_filters.py
+++ b/pt_backend/tests/test_filters.py
@@ -10,8 +10,7 @@ from pt_backend.filter.portal_filter import PortalFilter
 from pt_backend.filter.date_range_filter import DateRangeFilter
 from pt_backend.filter.service import CaseFilterService
 from pt_backend.models import Case, Disease, Location, News
-from datetime import timezone
-from datetime import datetime
+from datetime import datetime, timedelta
 import pytz
 import uuid
 from django.utils.dateparse import parse_datetime
@@ -119,6 +118,17 @@ class FilterTestCase(TestCase):
         expected_q = Q(news__date_published__lte=datetime(2024, 12, 31, 23, 59, 59, tzinfo=pytz.UTC)) & Q(news__isnull=False)
         self.assertEqual(str(result), str(expected_q))
 
+    def test_date_range_filter_with_timezone_normalization(self):
+        data = {
+            'start_date': '2024-01-01T00:00:00',
+            'timezone': 'Asia/Jakarta',
+        }
+        result = self.date_range_filter.apply(data)
+        localized = pytz.timezone('Asia/Jakarta').localize(datetime(2024, 1, 1, 0, 0))
+        expected_start = localized.astimezone(pytz.UTC)
+        expected_q = Q(news__date_published__gte=expected_start) & Q(news__isnull=False)
+        self.assertEqual(str(result), str(expected_q))
+
     def test_date_range_filter_with_invalid_format(self):
         data = {'start_date': 'invalid-date', 'end_date': 'invalid-date'}
         result = self.date_range_filter.apply(data)
@@ -142,6 +152,32 @@ class FilterTestCase(TestCase):
     def test_build_time_window_helper_without_dates_returns_none(self):
         result = DateRangeFilter.build_time_window(field="created_at", data={})
         self.assertIsNone(result)
+
+    def test_resolve_time_window_with_period_string(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': '7d'}
+        start, end = DateRangeFilter.resolve_time_window(data, now=fixed_now)
+        self.assertEqual(start, (fixed_now - timedelta(days=7)))
+        self.assertEqual(end, fixed_now)
+
+    def test_resolve_time_window_with_period_and_timezone(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': '24h', 'timezone': 'Asia/Jakarta'}
+        start, end = DateRangeFilter.resolve_time_window(data, now=fixed_now)
+        self.assertEqual(end, fixed_now)
+        self.assertEqual(start, fixed_now - timedelta(hours=24))
+
+    def test_resolve_time_window_with_invalid_timezone_falls_back_to_utc(self):
+        data = {'start_date': '2024-01-01T00:00:00', 'timezone': 'Invalid/TZ'}
+        start, _ = DateRangeFilter.resolve_time_window(data)
+        self.assertEqual(start, datetime(2024, 1, 1, 0, 0, tzinfo=pytz.UTC))
+
+    def test_resolve_time_window_with_period_dict(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': {'value': 2, 'unit': 'weeks'}}
+        start, end = DateRangeFilter.resolve_time_window(data, now=fixed_now)
+        self.assertEqual(end, fixed_now)
+        self.assertEqual(start, fixed_now - timedelta(weeks=2))
 
 
 
@@ -310,6 +346,33 @@ class CaseFilterServiceTest(TestCase):
     def test_time_window_helper_returns_none_without_bounds(self):
         result = CaseFilterService.time_window(data={}, field="news__date_published")
         self.assertIsNone(result)
+
+    def test_time_window_helper_with_period(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': '1d'}
+        result = CaseFilterService.time_window(
+            data,
+            field="news__date_published",
+            null_guard_field="news",
+            now=fixed_now,
+        )
+        expected_q = (
+            Q(
+                news__date_published__range=[
+                    fixed_now - timedelta(days=1),
+                    fixed_now,
+                ]
+            )
+            & Q(news__isnull=False)
+        )
+        self.assertEqual(str(result), str(expected_q))
+
+    def test_resolve_time_window_proxy(self):
+        fixed_now = datetime(2024, 1, 8, 12, 0, tzinfo=pytz.UTC)
+        data = {'period': '1d'}
+        start, end = CaseFilterService.resolve_time_window(data, now=fixed_now)
+        self.assertEqual(start, fixed_now - timedelta(days=1))
+        self.assertEqual(end, fixed_now)
 
     def test_filter_cases_with_none_returning_filter(self):
         mock_filter = Mock()

--- a/pt_backend/tests/test_filters.py
+++ b/pt_backend/tests/test_filters.py
@@ -129,6 +129,20 @@ class FilterTestCase(TestCase):
         result = self.date_range_filter.apply(data)
         self.assertEqual(str(result), str(Q()))
 
+    def test_build_time_window_helper_with_null_guard(self):
+        data = {'start_date': '2024-01-01T00:00:00Z'}
+        result = DateRangeFilter.build_time_window(
+            field="news__date_published",
+            data=data,
+            null_guard_field="news",
+        )
+        expected_q = Q(news__date_published__gte=datetime(2024, 1, 1, 0, 0, tzinfo=pytz.UTC)) & Q(news__isnull=False)
+        self.assertEqual(str(result), str(expected_q))
+
+    def test_build_time_window_helper_without_dates_returns_none(self):
+        result = DateRangeFilter.build_time_window(field="created_at", data={})
+        self.assertIsNone(result)
+
 
 
 class TestFilterStrategy(TestCase):
@@ -273,6 +287,29 @@ class CaseFilterServiceTest(TestCase):
         )
         self.mock_queryset.distinct.assert_called_once()
         self.assertEqual(result, ['mocked_result'])
+
+    def test_time_window_helper_exposure_matches_date_range_filter(self):
+        data = {
+            'start_date': '2024-01-01T00:00:00Z',
+            'end_date': '2024-01-02T23:59:59Z',
+        }
+        result = CaseFilterService.time_window(
+            data,
+            field="news__date_published",
+            null_guard_field="news",
+        )
+        expected_q = (
+            Q(news__date_published__range=[
+                datetime(2024, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                datetime(2024, 1, 2, 23, 59, 59, tzinfo=pytz.UTC),
+            ])
+            & Q(news__isnull=False)
+        )
+        self.assertEqual(str(result), str(expected_q))
+
+    def test_time_window_helper_returns_none_without_bounds(self):
+        result = CaseFilterService.time_window(data={}, field="news__date_published")
+        self.assertIsNone(result)
 
     def test_filter_cases_with_none_returning_filter(self):
         mock_filter = Mock()

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -1,20 +1,20 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
 from rest_framework import status
 from pantau_tular.settings import CACHES
-from pt_backend.models import Case, Location, Disease, News, User
+from pt_backend.models import Case, Location, Disease, News, User, DownloadEvent
 from pt_backend.services import CacheService
 from unittest.mock import patch, MagicMock
 from django.utils import timezone
-from datetime import datetime, timedelta
 import uuid
 import os
 from unittest.mock import patch, Mock
 from rest_framework_simplejwt.tokens import RefreshToken
 import json
 from ..views import StatisticsView, SeverityFilteringStatsView
+import pytz
 
 class CaseAPITest(TestCase):
     def setUp(self):
@@ -249,7 +249,10 @@ class StatisticsViewTest(TestCase):
         
         # Check that the date_range parameter was correctly set
         self.assertIn('date_range', call_args)
-        self.assertEqual(call_args['date_range']['start'], "2023-01-01")
+        self.assertEqual(
+            call_args['date_range']['start'],
+            datetime(2023, 1, 1, tzinfo=pytz.UTC)
+        )
         self.assertIsNone(call_args['date_range']['end'])
         
         # Verify the response contains the expected data
@@ -296,8 +299,14 @@ class StatisticsViewTest(TestCase):
         
         # Check that the date_range parameter was correctly set
         self.assertIn('date_range', call_args)
-        self.assertEqual(call_args['date_range']['start'], "2023-01-01")
-        self.assertEqual(call_args['date_range']['end'], "2023-12-31")
+        self.assertEqual(
+            call_args['date_range']['start'],
+            datetime(2023, 1, 1, tzinfo=pytz.UTC)
+        )
+        self.assertEqual(
+            call_args['date_range']['end'],
+            datetime(2023, 12, 31, tzinfo=pytz.UTC)
+        )
         
         # Verify the response contains the expected data
         self.assertIn("prevalence_statistics", response.data)
@@ -402,8 +411,14 @@ class StatisticsViewTest(TestCase):
         self.assertEqual(call_args['cities'], ["Jakarta"])
         self.assertEqual(call_args['portals'], ["kompas.com"])
         self.assertEqual(call_args['disease_alertness'], 2)
-        self.assertEqual(call_args['date_range']['start'], "2023-01-01")
-        self.assertEqual(call_args['date_range']['end'], "2023-06-30")
+        self.assertEqual(
+            call_args['date_range']['start'],
+            datetime(2023, 1, 1, tzinfo=pytz.UTC)
+        )
+        self.assertEqual(
+            call_args['date_range']['end'],
+            datetime(2023, 6, 30, tzinfo=pytz.UTC)
+        )
     
     def test_statistics_post_with_exception(self):
         """Test handling of exceptions in POST method"""
@@ -771,7 +786,10 @@ class SeverityFilteringStatsViewTest(TestCase):
             cities=None,
             news_portals=None,
             alert_levels=None,
-            date_range=("2023-01-01", "2023-12-31")
+            date_range=(
+                datetime(2023, 1, 1, tzinfo=pytz.UTC),
+                datetime(2023, 12, 31, tzinfo=pytz.UTC),
+            )
         )
     
     def test_post_with_portals_and_alertness(self):

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -66,7 +66,8 @@ class AllCaseLocationsView(APIView):
             if not request.data or all(not v for v in request.data.values()):
                 cases = self.service.get_all_case_locations()
             else: 
-                cases = self.filter_service.filter_cases(request.data)
+                payload = self._prepare_filter_payload(request.data)
+                cases = self.filter_service.filter_cases(payload)
 
             if not cases:
                 return Response(
@@ -86,6 +87,27 @@ class AllCaseLocationsView(APIView):
                 {"error": INTERNAL_SERVER_ERR_MSG},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+
+    def _prepare_filter_payload(self, data):
+        time_params = self.filter_service.parse_time_params(data)
+        payload = self._flatten_request_data(data)
+        if time_params:
+            payload.update(time_params)
+        return payload
+
+    @staticmethod
+    def _flatten_request_data(data):
+        if hasattr(data, "lists"):
+            flattened = {}
+            for key, values in data.lists():
+                if len(values) == 1:
+                    flattened[key] = values[0]
+                else:
+                    flattened[key] = values
+            return flattened
+        if isinstance(data, dict):
+            return {key: data[key] for key in data}
+        return dict(data)
 
 class FiltersView(APIView):
     def get(self, request):
@@ -340,14 +362,12 @@ class StatisticsView(APIView):
                 filter_params['disease_alertness'] = alertness
 
     def _add_date_range(self, request, filter_params):
-        start_date = request.data.get('start_date')
-        end_date = request.data.get('end_date')
-
-        if start_date or end_date:
-            filter_params['date_range'] = {
-                'start': start_date,
-                'end': end_date
-            }
+        time_range = CaseFilterService.parse_time_range(
+            request.data,
+            return_type="dict",
+        )
+        if time_range:
+            filter_params['date_range'] = time_range
 
     
 class SeverityFilteringStatsView(APIView):
@@ -366,19 +386,21 @@ class SeverityFilteringStatsView(APIView):
             filter_params = self._extract_filter_parameters(request.data)
             
             # Generate cache key based on filter parameters
-            # cache_key = self._generate_cache_key(filter_params)
-            
-            # Check if results are in cache
-            # cached_results = self.cache_service.get(cache_key)
-            # if cached_results:
-                # return Response(cached_results, status=status.HTTP_200_OK)
+            cached_results = self._generate_cache_key(filter_params)
+            cache_key = getattr(self, "_current_cache_key", None)
+
+            if cached_results is not None:
+                return Response(cached_results, status=status.HTTP_200_OK)
+
+            if cache_key is None:
+                raise ValueError("Unable to generate cache key")
             
             # Initialize service and get results if not in cache
             severity_filter = SeverityFilteringService()
             results = severity_filter.get_filter_stats(**filter_params)
             
             # Cache the results
-            # self.cache_service.set(cache_key, results, timeout=self.cache_timeout)
+            self.cache_service.set(cache_key, results, timeout=self.cache_timeout)
             
             return Response(results, status=status.HTTP_200_OK)
         
@@ -390,23 +412,33 @@ class SeverityFilteringStatsView(APIView):
     
     def _generate_cache_key(self, filter_params):
         try:
-            # Convert filter items to something hashable
             hashable_items = []
-            for k, v in filter_params.items():
-                if isinstance(v, list):
-                    v = tuple(v)  # Convert lists to tuples (which are hashable)
-                elif isinstance(v, dict):
-                    # Convert nested dictionaries to tuples of tuples
-                    v = tuple((k2, tuple(v2) if isinstance(v2, list) else v2) 
-                                for k2, v2 in v.items())
-                hashable_items.append((k, v))
+            for key, value in filter_params.items():
+                normalized = self._normalize_cache_value(value)
+                hashable_items.append((key, normalized))
             cache_key = f"{CACHE_KEY_PREFIX}{hash(frozenset(hashable_items))}"
-            cached_result = self.cache_service.get(cache_key)
-            if cached_result:
-                return cached_result
+            self._current_cache_key = cache_key
+            return self.cache_service.get(cache_key)
         except Exception as e:
             logger.error(f"Cache key generation error: {str(e)}")
-            return None
+            self._current_cache_key = None
+            raise
+
+    @staticmethod
+    def _normalize_cache_value(value):
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return tuple(
+                (k, SeverityFilteringStatsView._normalize_cache_value(v))
+                for k, v in sorted(value.items())
+            )
+        if isinstance(value, (list, tuple, set)):
+            return tuple(
+                SeverityFilteringStatsView._normalize_cache_value(v)
+                for v in value
+            )
+        return value
 
     
     def _extract_filter_parameters(self, data):
@@ -424,9 +456,11 @@ class SeverityFilteringStatsView(APIView):
         if level_of_alertness:
             level_of_alertness = int(level_of_alertness)
         
-        start_date = data.get('start_date')
-        end_date = data.get('end_date')
-        date_range = (start_date, end_date) if start_date or end_date else None
+        time_window = CaseFilterService.parse_time_range(
+            data,
+            return_type="tuple",
+        )
+        date_range = time_window if time_window else None
         
         return {
             'diseases': diseases,


### PR DESCRIPTION
This merge unifies request-level time parsing and date-range resolution under `CaseFilterService`. It introduces reusable helpers for start/end/period parameters and applies them across views. It also includes the corresponding test suite to validate parsing, resolver behavior, and view integration.

Key changes:

* Added request time parsers and normalized ISO/UTC handling.
* Implemented `DateRangeFilter` resolver and exposed via `CaseFilterService`.
* Updated views to route time-based filtering through the resolver.
* Added failing tests first, then implemented logic to satisfy them.
