### PR TITLE
[GREEN] Implement spatial comparison endpoint and routing

### DIFF
--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import (AllCaseLocationsView, CitySeverityStatsView, 
+from .views import (AllCaseLocationsView, SpatialComparisonView, CitySeverityStatsView, 
                     DiseaseSeverityStatsView, CaseDetailView, FiltersView, 
                     StatisticsView, LocationSeverityStatsView, SeverityFilteringStatsView,
                     ProvinceHumidityView, ProvincePrecipitationView, ProvinceTemperatureView,
@@ -8,6 +8,7 @@ from . import views
 
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),
+    path('cases/spatial-comparisons/', SpatialComparisonView.as_view(), name='spatial-comparisons'),
     path('api/filters/', FiltersView.as_view(), name='filters'),
     path('cases/<uuid:case_id>/', CaseDetailView.as_view(), name='case-detail'),
     path('api/diseases/severity-stats/', DiseaseSeverityStatsView.as_view(), name='disease-severity-stats'),

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -139,6 +139,117 @@ class AllCaseLocationsView(APIView):
             return {key: data[key] for key in data}
         return dict(data)
 
+
+class SpatialComparisonView(APIView):
+    """
+    Provide side-by-side spatial comparison data for multiple regions in one request.
+    Each region entry can be a string (treated as province/city name) or a mapping
+    with optional `label` and `filters` keys.
+    """
+
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = []
+    serializer_class = CaseLocationSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.filter_service = CaseFilterService()
+
+    def post(self, request):
+        try:
+            regions = self._extract_regions(request.data)
+        except ValueError as err:
+            return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)
+
+        comparisons = []
+        for index, region in enumerate(regions):
+            try:
+                label, filters = self._normalize_region(region, index)
+            except ValueError as err:
+                return Response(
+                    {"error": str(err), "region_index": index},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            try:
+                prepared_filters = self._prepare_filter_payload(filters)
+            except CaseFilterValidationError as err:
+                payload = err.as_payload()
+                payload["error"]["region_index"] = index
+                return Response(payload, status=status.HTTP_400_BAD_REQUEST)
+            try:
+                cases = self.filter_service.filter_cases(prepared_filters)
+            except CaseFilterValidationError as err:
+                payload = err.as_payload()
+                payload["error"]["region_index"] = index
+                return Response(payload, status=status.HTTP_400_BAD_REQUEST)
+
+            serialized = self.serializer_class(cases, many=True).data
+            comparisons.append(
+                {
+                    "label": label,
+                    "count": len(serialized),
+                    "locations": serialized,
+                    "filters": prepared_filters,
+                }
+            )
+
+        return Response({"comparisons": comparisons}, status=status.HTTP_200_OK)
+
+    def _extract_regions(self, data):
+        regions = (
+            data.get("regions")
+            or data.get("region")
+            or data.get("comparisons")
+        )
+        if regions is None:
+            raise ValueError("Field 'regions' is required for spatial comparison.")
+        if not isinstance(regions, list):
+            raise ValueError("Field 'regions' must be a list.")
+        if not regions:
+            raise ValueError("Please provide at least one region to compare.")
+        return regions
+
+    def _normalize_region(self, region, index):
+        if isinstance(region, str):
+            filters = {"locations": {"provinces": [region], "cities": [region]}}
+            return region, filters
+
+        if not isinstance(region, dict):
+            raise ValueError(f"Region entry at index {index} must be a string or mapping.")
+
+        label = (
+            region.get("label")
+            or region.get("name")
+            or region.get("province")
+            or region.get("city")
+            or f"Region {index + 1}"
+        )
+
+        raw_filters = region.get("filters", None)
+        if raw_filters is None:
+            raw_filters = {k: v for k, v in region.items() if k != "label"}
+
+        if not isinstance(raw_filters, dict):
+            raise ValueError(f"Filters for region '{label}' must be a mapping.")
+
+        filters = dict(raw_filters)
+        if "locations" not in filters:
+            if region.get("province"):
+                filters["locations"] = {"provinces": [region["province"]]}
+            elif region.get("city"):
+                filters["locations"] = {"cities": [region["city"]]}
+
+        return label, filters
+
+    def _prepare_filter_payload(self, data):
+        time_params = self.filter_service.parse_time_params(data)
+        payload = AllCaseLocationsView._flatten_request_data(data)
+        if time_params:
+            payload.update(time_params)
+        return payload
+
+
 class FiltersView(APIView):
     def get(self, request):
         disease_repository = DiseaseRepository()


### PR DESCRIPTION
This commit implements the spatial comparison endpoint and wires it into the backend routing. The pt_backend urls module now exposes a new path at cases slash spatial comparisons that is handled by the SpatialComparisonView. The view uses the API key authentication class and the existing case filter service to build comparison data for multiple regions in one request. The endpoint accepts a list of regions which can be simple strings or mapping objects with optional label province city and filters fields. The helper that extracts regions supports different input keys such as regions region and comparisons and returns clear error responses when the field is missing not a list or empty. The normaliser builds a human readable label for each region and ensures there is always a locations filter based on province or city when it is not already present. Time parameters are processed through the case filter service parse time method and merged into a flattened filter payload that matches the filters used by the all case locations view. For each region the service filters the cases and the view returns a comparison entry that contains the label the total count the list of locations and the filters used. Validation errors from time parsing or case filtering are caught and returned as structured error payloads that include field messages and the index of the region that failed so the client can match errors back to the original input. This green commit completes the behaviour that was described earlier by the spatial comparison tests.