### PR TITLE
Pbi 16 contribution management

### DIFF
--- a/curator_feature/permissions.py
+++ b/curator_feature/permissions.py
@@ -2,7 +2,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.permissions import SAFE_METHODS
 from authentication.permissions import IsTokenAuthenticated
 
-ALLOWED_ROLES = {"CURATOR", "ADMIN", "EXP_USER"}  # adjust if needed
+ALLOWED_ROLES = {"CURATOR", "ADMIN"}  # only curator/admin can manage
 
 class IsCuratorRole(BasePermission):
     """

--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -1406,6 +1406,15 @@ class PermissionCoverageTests(TestCase):
         perm = IsCuratorRole()
         self.assertFalse(perm.has_permission(request, None))
 
+    def test_is_curator_role_allows_admin_but_denies_other_roles(self):
+        """Admin permitted; other non-curator roles (e.g., EXP_USER) denied."""
+        perm = IsCuratorRole()
+        admin_req = SimpleNamespace(user=SimpleNamespace(role="ADMIN"))
+        exp_req = SimpleNamespace(user=SimpleNamespace(role="EXP_USER"))
+
+        self.assertTrue(perm.has_permission(admin_req, None))
+        self.assertFalse(perm.has_permission(exp_req, None))
+
     def test_readonly_or_curator_allows_safe_methods(self):
         """Covers lines 22–23: safe methods return True."""
         request = self.factory.get("/dummy")


### PR DESCRIPTION
This PR enforces the curator feature permission guard to allow only CURATOR and ADMIN roles (EXP_USER and others blocked). Adds tests covering admin-allowed and non-curator-denied cases to back the guard. No behavior changes beyond tightening access control.