### PR TITLE
Pbi 16 contribution management

### DIFF
--- a/curator_feature/models.py
+++ b/curator_feature/models.py
@@ -120,7 +120,7 @@ class ContributorSubmission(models.Model):
     status = models.CharField(max_length=30, choices=STATUS_CHOICES, default="WAITING_FOR_APPROVAL")
 
     has_unseen_update = models.BooleanField(default=False)
-    last_notified_status = models.CharField(max_length=30, blank=True, null=True)
+    last_notified_status = models.CharField(max_length=30, blank=True, default="")
 
     created_at = models.DateTimeField(auto_now_add=True)
     reviewed_at = models.DateTimeField(null=True, blank=True)

--- a/curator_feature/models.py
+++ b/curator_feature/models.py
@@ -119,6 +119,9 @@ class ContributorSubmission(models.Model):
     submitted_by = models.CharField(max_length=150)
     status = models.CharField(max_length=30, choices=STATUS_CHOICES, default="WAITING_FOR_APPROVAL")
 
+    has_unseen_update = models.BooleanField(default=False)
+    last_notified_status = models.CharField(max_length=30, blank=True, null=True)
+
     created_at = models.DateTimeField(auto_now_add=True)
     reviewed_at = models.DateTimeField(null=True, blank=True)
 

--- a/curator_feature/serializers.py
+++ b/curator_feature/serializers.py
@@ -323,18 +323,36 @@ class CaseReadSerializer(serializers.ModelSerializer):
 
 class ContributorSubmissionListSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source="submitted_by", read_only=True)
-
-    class Meta:
-        model = ContributorSubmission
-        fields = ("id", "title", "status", "username", "created_at")
-
-
-class ContributorSubmissionDetailSerializer(serializers.ModelSerializer):
-    username = serializers.CharField(source="submitted_by", read_only=True)
+    hasUnseenUpdate = serializers.BooleanField(source="has_unseen_update", read_only=True)
 
     class Meta:
         model = ContributorSubmission
         fields = (
-            "id", "title", "content", "status",
-            "username", "created_at", "reviewed_at",
+            "id",
+            "title",
+            "status",
+            "username",
+            "created_at",
+            "hasUnseenUpdate",
+        )
+
+
+
+class ContributorSubmissionDetailSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source="submitted_by", read_only=True)
+    hasUnseenUpdate = serializers.BooleanField(source="has_unseen_update", read_only=True)
+    lastNotifiedStatus = serializers.CharField(source="last_notified_status", read_only=True)
+
+    class Meta:
+        model = ContributorSubmission
+        fields = (
+            "id",
+            "title",
+            "content",
+            "status",
+            "username",
+            "created_at",
+            "reviewed_at",
+            "hasUnseenUpdate",
+            "lastNotifiedStatus",
         )

--- a/curator_feature/services.py
+++ b/curator_feature/services.py
@@ -453,7 +453,9 @@ class ContributorSubmissionService:
 
         sub.status = new_status
         sub.reviewed_at = timezone.now()
-        sub.save(update_fields=["status", "reviewed_at"])
+        sub.has_unseen_update = True
+        sub.last_notified_status = new_status
+        sub.save(update_fields=["status", "reviewed_at", "has_unseen_update", "last_notified_status"])
 
         # audit log (safe)
         try:

--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -2104,14 +2104,13 @@ class ContributorSubmissionViewExceptionTests(TestCase):
 
         self.assertEqual(res.status_code, 400)
         self.assertIn("status", res.data)
-        
+
 # ============================================================
 # CONTRIBUTOR SUBMISSION – NEW FIELDS & MARK-SEEN TESTS
 # ============================================================
 
 class ContributorSubmissionNewFieldsTests(TestCase):
     def test_model_defaults(self):
-        """Ensure new fields have correct default values."""
         sub = ContributorSubmission.objects.create(
             id=uuid.uuid4(),
             title="Title",
@@ -2120,8 +2119,11 @@ class ContributorSubmissionNewFieldsTests(TestCase):
         )
 
         self.assertFalse(sub.has_unseen_update)
-        self.assertIsNone(sub.last_notified_status)
+
+        self.assertEqual("", sub.last_notified_status)
+
         self.assertIsNotNone(sub.created_at)
+
         self.assertIsNone(sub.reviewed_at)
 
 

--- a/curator_feature/tests.py
+++ b/curator_feature/tests.py
@@ -2104,3 +2104,120 @@ class ContributorSubmissionViewExceptionTests(TestCase):
 
         self.assertEqual(res.status_code, 400)
         self.assertIn("status", res.data)
+        
+# ============================================================
+# CONTRIBUTOR SUBMISSION – NEW FIELDS & MARK-SEEN TESTS
+# ============================================================
+
+class ContributorSubmissionNewFieldsTests(TestCase):
+    def test_model_defaults(self):
+        """Ensure new fields have correct default values."""
+        sub = ContributorSubmission.objects.create(
+            id=uuid.uuid4(),
+            title="Title",
+            content="Content",
+            submitted_by="alice",
+        )
+
+        self.assertFalse(sub.has_unseen_update)
+        self.assertIsNone(sub.last_notified_status)
+        self.assertIsNotNone(sub.created_at)
+        self.assertIsNone(sub.reviewed_at)
+
+
+class ContributorSubmissionSerializerNewFieldsTests(TestCase):
+    def test_list_serializer_includes_hasUnseenUpdate(self):
+        sub = ContributorSubmission.objects.create(
+            id=uuid.uuid4(),
+            title="T",
+            content="C",
+            submitted_by="alice",
+            has_unseen_update=True,
+        )
+
+        from curator_feature.serializers import ContributorSubmissionListSerializer
+        data = ContributorSubmissionListSerializer(sub).data
+
+        self.assertIn("hasUnseenUpdate", data)
+        self.assertTrue(data["hasUnseenUpdate"])
+
+    def test_detail_serializer_includes_lastNotifiedStatus(self):
+        sub = ContributorSubmission.objects.create(
+            id=uuid.uuid4(),
+            title="T",
+            content="C",
+            submitted_by="alice",
+            has_unseen_update=True,
+            last_notified_status="REJECTED",
+        )
+
+        from curator_feature.serializers import ContributorSubmissionDetailSerializer
+        data = ContributorSubmissionDetailSerializer(sub).data
+
+        self.assertTrue(data["hasUnseenUpdate"])
+        self.assertEqual(data["lastNotifiedStatus"], "REJECTED")
+
+
+class ContributorSubmissionServiceFlagTests(TestCase):
+    def setUp(self):
+        self.service = ContributorSubmissionService()
+        self.curator = PtUser.objects.create(
+            id=1234,
+            name="Curator",
+            email="c@example.com",
+            password="x",
+            role="CURATOR",
+        )
+        self.sub = ContributorSubmission.objects.create(
+            id=uuid.uuid4(),
+            title="X",
+            content="Y",
+            submitted_by="bob",
+        )
+
+    def test_status_update_sets_unseen_and_notified_fields(self):
+        updated = self.service.update_status(
+            submission_id=self.sub.id,
+            new_status="APPROVED",
+            reviewer=self.curator,
+        )
+
+        self.assertTrue(updated.has_unseen_update)
+        self.assertEqual(updated.last_notified_status, "APPROVED")
+
+
+class ContributorSubmissionMarkSeenAPI(TestCase):
+    """
+    Covers PATCH /submissions/<id>/mark-seen/
+    """
+    def setUp(self):
+        self.client = APIClient()
+        self.user = PtUser.objects.create(
+            name="Curator",
+            email="c@example.com",
+            password="x",
+            role="CURATOR",
+        )
+        token = RefreshToken.for_user(self.user).access_token
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        self.sub = ContributorSubmission.objects.create(
+            id=uuid.uuid4(),
+            title="A",
+            content="B",
+            submitted_by="alice",
+            has_unseen_update=True,
+        )
+
+    def test_mark_seen_resets_flag(self):
+        url = f"/curator-feature/submissions/{self.sub.id}/mark-seen/"
+        res = self.client.patch(url, format="json")
+
+        self.assertEqual(res.status_code, 200)
+        self.sub.refresh_from_db()
+        self.assertFalse(self.sub.has_unseen_update)
+
+    def test_mark_seen_404_when_not_found(self):
+        url = "/curator-feature/submissions/00000000-0000-0000-0000-000000000000/mark-seen/"
+        res = self.client.patch(url, format="json")
+        self.assertEqual(res.status_code, 404)

--- a/curator_feature/urls.py
+++ b/curator_feature/urls.py
@@ -13,7 +13,8 @@ from curator_feature.views import (
     CuratorDataLogListCreateAPIView,
     ContributorSubmissionListView,
     ContributorSubmissionDetailView,
-    ContributorSubmissionStatusUpdateView
+    ContributorSubmissionStatusUpdateView,
+    ContributorSubmissionMarkSeenView,
 )
 
 urlpatterns = [
@@ -37,6 +38,6 @@ urlpatterns = [
     path("submissions/", ContributorSubmissionListView.as_view(), name="curator-submission-list"),
     path("submissions/<uuid:id>/", ContributorSubmissionDetailView.as_view(), name="curator-submission-detail"),
     path("submissions/<uuid:id>/status/", ContributorSubmissionStatusUpdateView.as_view(), name="curator-submission-status"),
-    path("curator/submissions/<uuid:id>/status/", ContributorSubmissionStatusUpdateView.as_view(), name="curator-submission-status-alias",
-    ),
+    path("curator/submissions/<uuid:id>/status/", ContributorSubmissionStatusUpdateView.as_view(), name="curator-submission-status-alias"),
+    path("submissions/<uuid:id>/mark-seen/", ContributorSubmissionMarkSeenView.as_view(), name="submission-mark-seen"),
 ]

--- a/curator_feature/views.py
+++ b/curator_feature/views.py
@@ -481,3 +481,18 @@ class ContributorSubmissionStatusUpdateView(_CuratorBaseView, APIView):
             ContributorSubmissionDetailSerializer(updated).data,
             status=status.HTTP_200_OK,
         )
+
+class ContributorSubmissionMarkSeenView(_CuratorBaseView, APIView):
+    service = ContributorSubmissionService()
+
+    def patch(self, request, id):
+        try:
+            sub = self.service.get(id)
+        except Exception as exc:
+            return Response({"detail": str(exc)}, status=404)
+
+        # reset flags
+        sub.has_unseen_update = False
+        sub.save(update_fields=["has_unseen_update"])
+
+        return Response({"seen": True}, status=200)


### PR DESCRIPTION
Implements contributor update notification workflow for PBI/SCRUM-205. Curators can now mark contributor submissions as reviewed, triggering update flags and audit logging.

Changes Included:
- Added `has_unseen_update` + `last_notified_status` fields to `ContributorSubmission` model.
- Updated detail & list serializers to expose notification flags.
- Extended `ContributorSubmissionService.update_status()` to set flags and create audit logs.
- Added new endpoint `/submissions/<id>/mark-seen/` to let contributors mark notifications as read.
- Added complete test coverage for new workflow (view, service, serializer, and model).

Testing:
All new tests pass. No existing tests were removed.  
This PR does *not* delete or mutate existing production data.
