### PR TITLE
Pbi 15 news salads

### DIFF
--- a/news_feature/api.py
+++ b/news_feature/api.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from pt_backend.models import News
 
 from news_feature.serializers import NewsArticleSerializer
-from news_feature.services.filtering import filter_news
+from news_feature.services.filtering import build_filter_params, filter_news
 
 
 class NewsPagination(pagination.PageNumberPagination):
@@ -31,13 +31,5 @@ class NewsArticleViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         base_qs = News.objects.all().order_by("-date_published")
-        params = {
-            "search": self.request.query_params.get("search"),
-            "source": self.request.query_params.get("source"),
-            "tags": self.request.query_params.get("tags"),
-            "curated_only": self.request.query_params.get("curated_only"),
-            "from_date": self.request.query_params.get("from_date"),
-            "to_date": self.request.query_params.get("to_date"),
-            "has_image": self.request.query_params.get("has_image"),
-        }
+        params = build_filter_params(self.request.query_params)
         return filter_news(base_qs, params)

--- a/news_feature/services/filtering.py
+++ b/news_feature/services/filtering.py
@@ -1,55 +1,80 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Union
 
 from django.db.models import Q, QuerySet
-from django.utils import timezone
-from django.utils.dateparse import parse_datetime
 
 from news_feature.constants import CURATED_TYPE_KEYWORDS
+from news_feature.services.normalization import NewsNormalizer
 
-def filter_news(qs: QuerySet, params: dict) -> QuerySet:
+
+@dataclass(frozen=True)
+class NewsFilterParams:
+    search: str = ""
+    sources: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    curated_only: bool = False
+    from_date: Optional[datetime] = None
+    to_date: Optional[datetime] = None
+    has_image: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Optional[Mapping[str, Any]] = None) -> "NewsFilterParams":
+        data = data or {}
+        return cls(
+            search=_clean_str(_get_param(data, "search")),
+            sources=tuple(_parse_csv(_get_param(data, "source"))),
+            tags=tuple(_parse_csv(_get_param(data, "tags"))),
+            curated_only=_to_bool(_get_param(data, "curated_only")),
+            from_date=_parse_datetime(_get_param(data, "from_date")),
+            to_date=_parse_datetime(_get_param(data, "to_date")),
+            has_image=_to_bool(_get_param(data, "has_image")),
+        )
+
+
+def build_filter_params(data: Optional[Mapping[str, Any]] = None) -> NewsFilterParams:
+    return NewsFilterParams.from_dict(data)
+
+
+def filter_news(qs: QuerySet, params: Union[NewsFilterParams, Mapping[str, Any], None]) -> QuerySet:
     """
     Apply query-parameter-driven filters to a NewsArticle queryset.
     """
-    search_term = _clean_str(params.get("search"))
-    if search_term:
-        qs = qs.filter(
-            Q(title__icontains=search_term) | Q(content__icontains=search_term)
-        )
+    parsed = params if isinstance(params, NewsFilterParams) else NewsFilterParams.from_dict(params)
 
-    sources = _parse_csv(params.get("source"))
-    if sources:
-        qs = qs.filter(portal__in=sources)
+    if parsed.search:
+        qs = qs.filter(Q(title__icontains=parsed.search) | Q(content__icontains=parsed.search))
 
-    tags = _parse_csv(params.get("tags"))
-    if tags:
+    if parsed.sources:
+        qs = qs.filter(portal__in=parsed.sources)
+
+    if parsed.tags:
         tag_filter = Q()
-        for tag in tags:
+        for tag in parsed.tags:
             tag_filter |= Q(type__iexact=tag)
         qs = qs.filter(tag_filter)
 
-    if _to_bool(params.get("curated_only")):
+    if parsed.curated_only:
         curated_filter = Q()
         for keyword in CURATED_TYPE_KEYWORDS:
             curated_filter |= Q(type__iexact=keyword)
         qs = qs.filter(curated_filter)
 
-    from_date = _parse_datetime(params.get("from_date"))
-    if from_date:
-        qs = qs.filter(date_published__gte=from_date)
+    if parsed.from_date:
+        qs = qs.filter(date_published__gte=parsed.from_date)
 
-    to_date = _parse_datetime(params.get("to_date"))
-    if to_date:
-        qs = qs.filter(date_published__lte=to_date)
+    if parsed.to_date:
+        qs = qs.filter(date_published__lte=parsed.to_date)
 
-    if _to_bool(params.get("has_image")):
+    if parsed.has_image:
         qs = qs.exclude(Q(img_url__isnull=True) | Q(img_url__exact=""))
 
     return qs
 
 
-def _parse_csv(value: Optional[str]) -> List[str]:
+def _parse_csv(value: Optional[Union[str, Sequence[str]]]) -> List[str]:
     if not value:
         return []
     if isinstance(value, (list, tuple)):
@@ -60,20 +85,8 @@ def _parse_csv(value: Optional[str]) -> List[str]:
     return parsed
 
 
-def _parse_datetime(value) -> Optional[timezone.datetime]:
-    if isinstance(value, timezone.datetime):
-        dt = value
-    elif value:
-        dt = parse_datetime(str(value))
-    else:
-        return None
-
-    if dt is None:
-        return None
-
-    if timezone.is_naive(dt):
-        dt = timezone.make_aware(dt, timezone.get_current_timezone())
-    return dt
+def _parse_datetime(value) -> Optional[datetime]:
+    return NewsNormalizer.parse_datetime(value)
 
 
 def _to_bool(value) -> bool:
@@ -90,3 +103,15 @@ def _clean_str(value: Optional[str]) -> str:
     if not isinstance(value, str):
         return ""
     return value.strip()
+
+
+def _get_param(data: Mapping[str, Any], key: str) -> Any:
+    getter = getattr(data, "getlist", None)
+    if callable(getter):
+        values = getter(key)
+        if not values:
+            return None
+        if len(values) == 1:
+            return values[0]
+        return values
+    return data.get(key)

--- a/news_feature/tests/test_services_filtering.py
+++ b/news_feature/tests/test_services_filtering.py
@@ -1,11 +1,14 @@
 from datetime import datetime, timezone as dt_timezone
 import uuid
 
+from django.http import QueryDict
 from django.test import SimpleTestCase, TestCase
 
 from pt_backend.models import Case, Disease, Location, News
 
 from news_feature.services.filtering import (
+    NewsFilterParams,
+    build_filter_params,
     filter_news,
     _parse_csv,
     _parse_datetime,
@@ -121,6 +124,15 @@ class FilterNewsTests(TestCase):
         qs = filter_news(News.objects.all(), params)
         self.assertCountEqual(qs, [self.article_3])
 
+    def test_filter_accepts_dataclass_instance(self):
+        params = NewsFilterParams(
+            search="policy",
+            tags=("kurasi",),
+            curated_only=True,
+        )
+        qs = filter_news(News.objects.all(), params)
+        self.assertCountEqual(qs, [self.article_3])
+
 
 class FilterHelperTests(SimpleTestCase):
     def test_parse_csv_handles_lists(self):
@@ -145,3 +157,25 @@ class FilterHelperTests(SimpleTestCase):
         self.assertFalse(_to_bool(None))
         self.assertTrue(_to_bool(5))
         self.assertFalse(_to_bool(0))
+
+
+class FilterParamsTests(SimpleTestCase):
+    def test_build_filter_params_handles_querydict(self):
+        query = QueryDict("source=Kompas&source=Detik&tags=Kurasi&tags=Health&curated_only=true&has_image=1")
+        query = query.copy()
+        query["from_date"] = datetime(2025, 1, 1, tzinfo=dt_timezone.utc).isoformat()
+        query["to_date"] = datetime(2025, 1, 31, tzinfo=dt_timezone.utc).isoformat()
+
+        params = build_filter_params(query)
+
+        self.assertEqual(params.sources, ("Kompas", "Detik"))
+        self.assertEqual(params.tags, ("Kurasi", "Health"))
+        self.assertTrue(params.curated_only)
+        self.assertTrue(params.has_image)
+        self.assertEqual(params.from_date, datetime(2025, 1, 1, tzinfo=dt_timezone.utc))
+        self.assertEqual(params.to_date, datetime(2025, 1, 31, tzinfo=dt_timezone.utc))
+
+    def test_default_params_when_none_passed(self):
+        params = build_filter_params(None)
+        self.assertEqual(params.search, "")
+        self.assertFalse(params.curated_only)


### PR DESCRIPTION
This pull request refactors the news filtering logic to use a new `NewsFilterParams` dataclass for parameter management, improving code clarity and robustness. It introduces helper functions to build and parse filter parameters, updates the API to use these helpers, and adds comprehensive tests for the new functionality.

**Filtering logic and parameter handling improvements:**

* Added a frozen `NewsFilterParams` dataclass to represent filter parameters in a structured way, replacing ad-hoc dictionaries. Includes a `from_dict` class method for parsing from mappings and a `build_filter_params` helper function. (`news_feature/services/filtering.py`)
* Refactored `filter_news` to accept either a `NewsFilterParams` instance or a mapping, and to use the dataclass for all filter logic, simplifying and standardizing parameter handling. (`news_feature/services/filtering.py`)
* Improved helper functions: `_parse_csv` now handles sequences as well as strings, `_parse_datetime` now delegates to `NewsNormalizer.parse_datetime`, and `_get_param` supports Django `QueryDict` objects with `getlist`. (`news_feature/services/filtering.py`) [[1]](diffhunk://#diff-449264af656a339dd0c389dc7868203c5f62b57a3ec45941cafb6fe97afd28a3L63-R89) [[2]](diffhunk://#diff-449264af656a339dd0c389dc7868203c5f62b57a3ec45941cafb6fe97afd28a3R106-R117)

**API changes:**

* Updated `NewsArticleViewSet.get_queryset` to use `build_filter_params` for extracting filter parameters from query data, ensuring consistent parameter parsing. (`news_feature/api.py`) [[1]](diffhunk://#diff-e28359121a4fbd5f03efd903f5016369b05852be9ba7bf526cf455310ad278a4L9-R9) [[2]](diffhunk://#diff-e28359121a4fbd5f03efd903f5016369b05852be9ba7bf526cf455310ad278a4L34-R34)

**Testing enhancements:**

* Added tests for building filter parameters from a `QueryDict`, verifying correct parsing of multi-valued and date fields, and for default parameter values. Also tested that `filter_news` accepts a dataclass instance. (`news_feature/tests/test_services_filtering.py`) [[1]](diffhunk://#diff-72a07e272f428938e170032af372373eb955c64e5708dbd4b8b6cd99eaad1399R127-R135) [[2]](diffhunk://#diff-72a07e272f428938e170032af372373eb955c64e5708dbd4b8b6cd99eaad1399R160-R181)