### PR TITLE
Pbi 15 news salads

### DIFF
--- a/news_feature/tests/test_management_commands.py
+++ b/news_feature/tests/test_management_commands.py
@@ -1,7 +1,10 @@
+from django.contrib.auth.hashers import make_password
 from django.core.management import call_command
 from django.test import TestCase
 
-from pt_backend.models import Case, News
+from pt_backend.models import Case, News, User
+
+from news_feature.management.commands.seed_news_articles import Command, SEED_USER_EMAIL
 
 
 class SeedNewsArticlesCommandTests(TestCase):
@@ -19,3 +22,17 @@ class SeedNewsArticlesCommandTests(TestCase):
             3,
             "Command should be idempotent on repeated runs.",
         )
+
+    def test_ensure_case_resets_non_placeholder_password(self):
+        user = User.objects.create(
+            email=SEED_USER_EMAIL,
+            name="Seeder",
+            role="CURATOR",
+            password=make_password("not-placeholder"),
+        )
+        command = Command()
+
+        command._ensure_case()
+
+        user.refresh_from_db()
+        self.assertTrue(user.password.startswith("!"))

--- a/news_feature/tests/test_services_fetcher.py
+++ b/news_feature/tests/test_services_fetcher.py
@@ -522,4 +522,14 @@ class IngestorCoverageUnitTests(SimpleTestCase):
         payload_missing = self._payload(external_id="no-hit", source_url="https://example.com/legacy")
         self.assertEqual(self.ingestor._match_existing(legacy, payload_missing), "from-url")
 
-   
+    def test_update_article_from_payload_calls_assembler(self):
+        article = object()
+        payload = self._payload()
+
+        self.ingestor._update_article_from_payload(article, payload)
+
+        self.assertEqual(self.assembler.apply_calls, [(article, payload)])
+
+    def test_coerce_helpers_trim_and_normalize(self):
+        self.assertEqual(self.ingestor._coerce_text("  hello "), "hello")
+        self.assertEqual(self.ingestor._coerce_optional_text(None), "")

--- a/news_feature/tests/test_services_fetcher.py
+++ b/news_feature/tests/test_services_fetcher.py
@@ -4,7 +4,10 @@ from django.test import SimpleTestCase, TestCase, override_settings
 
 from news_feature.models import NewsArticle
 from news_feature.services.fetcher import (
+    ArticlePersistenceExecutor,
     ArticlePersistencePlan,
+    ArticlePlanBuilder,
+    ExistingArticleIndex,
     ExternalNewsClient,
     NewsIngestor,
     NewsPayload,
@@ -416,3 +419,107 @@ class IngestorBackcompatUnitTests(SimpleTestCase):
         result = self.ingestor._store_articles(plan)
 
         self.assertEqual(result, [])
+
+
+class StubAssembler:
+    def __init__(self):
+        self.build_calls = []
+        self.apply_calls = []
+        self.next_article = object()
+
+    def build(self, payload):
+        self.build_calls.append(payload)
+        return {"article": payload.external_id or payload.source_url}
+
+    def apply(self, article, payload):
+        self.apply_calls.append((article, payload))
+
+
+class StubRepository:
+    def __init__(self):
+        self.saved = []
+        self.updated = []
+
+    def build_index(self, normalized_items):
+        return ExistingArticleIndex.empty()
+
+    def save_new(self, articles):
+        self.saved.extend(articles)
+        return list(articles)
+
+    def update_existing(self, articles):
+        self.updated.extend(articles)
+        return list(articles)
+
+
+class IngestorCoverageUnitTests(SimpleTestCase):
+    def setUp(self):
+        self.assembler = StubAssembler()
+        self.repository = StubRepository()
+        self.ingestor = NewsIngestor(
+            client=FakeClient([]),
+            assembler=self.assembler,
+            repository=self.repository,
+            plan_builder=ArticlePlanBuilder(self.assembler),
+            persister=ArticlePersistenceExecutor(self.repository),
+        )
+
+    def _payload(self, **overrides):
+        base = {
+            "title": "Coverage",
+            "summary": "S",
+            "source_url": "https://example.com/coverage",
+            "source_name": "Source",
+            "thumbnail_url": "",
+            "published_at": datetime(2025, 1, 1, tzinfo=dt_timezone.utc),
+            "external_id": "ext-coverage",
+        }
+        base.update(overrides)
+        return NewsPayload(**base)
+
+    def test_build_article_uses_custom_assembler(self):
+        payload = self._payload()
+        result = self.ingestor._build_article(payload)
+
+        self.assertEqual(result, {"article": "ext-coverage"})
+        self.assertEqual(self.assembler.build_calls, [payload])
+
+    def test_save_and_update_articles_delegate_to_repository(self):
+        articles = ["new-a", "new-b"]
+        updated = ["update-a"]
+
+        self.assertEqual(self.ingestor._save_new_articles(articles), articles)
+        self.assertEqual(self.repository.saved, articles)
+
+        self.assertEqual(self.ingestor._update_existing_articles(updated), updated)
+        self.assertEqual(self.repository.updated, updated)
+
+    def test_match_existing_prefers_index_and_legacy_dict(self):
+        class Index(ExistingArticleIndex):
+            def __init__(self):
+                super().__init__()
+                self.called = False
+
+            def match(self, payload):
+                self.called = True
+                return "indexed"
+
+        index = Index()
+        payload = self._payload()
+        self.assertEqual(self.ingestor._match_existing(index, payload), "indexed")
+        self.assertTrue(index.called)
+
+        legacy = {
+            "external": {"ext-legacy": "from-external"},
+            "url": {"https://example.com/legacy": "from-url"},
+        }
+        payload_ext = self._payload(external_id="ext-legacy", source_url="https://example.com/legacy")
+        self.assertEqual(self.ingestor._match_existing(legacy, payload_ext), "from-external")
+
+        payload_url = self._payload(external_id="", source_url="https://example.com/legacy")
+        self.assertEqual(self.ingestor._match_existing(legacy, payload_url), "from-url")
+
+        payload_missing = self._payload(external_id="no-hit", source_url="https://example.com/legacy")
+        self.assertEqual(self.ingestor._match_existing(legacy, payload_missing), "from-url")
+
+   


### PR DESCRIPTION
This pull request adds new unit tests and test helpers to improve coverage for the news ingestion logic, and introduces a test for password reset behavior in the management command. The most important changes are the addition of comprehensive unit tests for `NewsIngestor`, including custom stub classes to isolate logic, and a new test for user password handling in the seeding command.

**Expanded test coverage for news ingestion:**

* Added the `IngestorCoverageUnitTests` test case to `news_feature/tests/test_services_fetcher.py`, which uses custom stub classes (`StubAssembler`, `StubRepository`) to isolate and verify the behavior of `NewsIngestor` methods, including article building, saving/updating, matching existing articles, updating from payload, and text normalization helpers.

* Introduced imports for `ArticlePersistenceExecutor`, `ArticlePlanBuilder`, and `ExistingArticleIndex` to support new and existing tests for the ingestion pipeline.

**Management command password handling:**

* Added a test `test_ensure_case_resets_non_placeholder_password` in `news_feature/tests/test_management_commands.py` to verify that the `_ensure_case` method in the seeding command resets a user's password to a placeholder value if it is not already a placeholder.

* Imported `make_password`, `User`, and `SEED_USER_EMAIL` in `news_feature/tests/test_management_commands.py` to support the new password reset test.