### PR TITLE
[REFACTOR] Include news/contributor apps in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ COPY authentication/ authentication/
 COPY admin_feature/ admin_feature/
 COPY curator_feature/ curator_feature/
 COPY expert_user_feature/ expert_user_feature/
+COPY news_feature/ news_feature/
+COPY contributor_feature/ contributor_feature/
 # COPY templates/ templates/
 # COPY staticfiles/ staticfiles/  
 


### PR DESCRIPTION
This update adds the news and contributor apps to the Docker build so they are included when the image is created. This helps make sure all features work correctly inside the container and keeps the project setup more complete and consistent.